### PR TITLE
value user interface and doAssert value use JsonOneLine parse value

### DIFF
--- a/actions/assert/1.0/internal/pkg/build/execute.go
+++ b/actions/assert/1.0/internal/pkg/build/execute.go
@@ -25,13 +25,13 @@ func Execute() error {
 func build(cfg conf.Conf) error {
 	var allSuccess = true
 	for _, v := range cfg.Assert {
-		success, err := assert.DoAssert(v.ActualValue, v.Assert, v.Value)
+		success, err := assert.DoAssert(v.ActualValue, v.Assert, jsonparse.JsonOneLine(v.Value))
 		if err != nil || !success {
 			allSuccess = false
 		}
 		// to assert
 		logrus.Infof("Assert Result:")
-		logrus.Infof("  value: %v", v.Value)
+		logrus.Infof("  value: %v", jsonparse.JsonOneLine(v.Value))
 		logrus.Infof("  assert: %v", v.Assert)
 		logrus.Infof("  actualValue: %s", jsonparse.JsonOneLine(v.ActualValue))
 		logrus.Infof("  success: %v", success)

--- a/actions/assert/1.0/internal/pkg/conf/conf.go
+++ b/actions/assert/1.0/internal/pkg/conf/conf.go
@@ -9,7 +9,7 @@ type Conf struct {
 }
 
 type Assert struct {
-	Value       string      `json:"value"`
+	Value       interface{} `json:"value"`
 	Assert      string      `json:"assert"`
 	ActualValue interface{} `json:"actualValue"`
 }


### PR DESCRIPTION
value use number will return error: `panic: failed to parse json ENV: ACTION_ASSERTS, value: [{"actualValue":"1","assert":"=","value":1}], err: json: cannot unmarshal number into Go struct field Assert.value of type string`, so change value type use interface