### PR TITLE
reportengine support namespaced erda

### DIFF
--- a/actions/reportengine/1.0/dice.yml
+++ b/actions/reportengine/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   reportengine:
-    image: registry.erda.cloud/erda-actions/dice-reportengine:3.15.0-20200618-937e5ad
+    image: registry.erda.cloud/erda/reportengine:1.1-20210709-5488ec1
     resources:
       cpu: 0.1
       mem: 128

--- a/actions/reportengine/1.0/spec.yml
+++ b/actions/reportengine/1.0/spec.yml
@@ -21,3 +21,10 @@ params:
   - name: org_name
     type: string
     requried: true
+  - name: monitor_addr
+    type: string
+    required: true
+  - name: eventbox_addr
+    type: string
+    required: true
+


### PR DESCRIPTION
fix reportengine when erda isn't in default namespace