### PR TITLE
release action check application mode, project_service mode cannot ploy

### DIFF
--- a/actions/release/1.0/spec.yml
+++ b/actions/release/1.0/spec.yml
@@ -82,6 +82,10 @@ accessibleAPIs:
   - path: /api/files
     method: POST
     schema: http
+  # get app type
+  - path: /api/applications/<applicationId>
+    method: GET
+    schema: http
 
 outputs:
   - name: releaseID


### PR DESCRIPTION
test link: [test](https://erda.dev.terminus.io/terminus/dop/projects/2/apps/124/repo)

this application was originally a normal application, I executed the pipeline to be deployed, and then I manually modified the application mode to a project_service application, and then the deployment reported an error
