### PR TITLE
add Asynchronous ability for testplan-run action

### DIFF
--- a/actions/testplan-run/1.0/internal/conf/conf.go
+++ b/actions/testplan-run/1.0/internal/conf/conf.go
@@ -4,8 +4,9 @@ import "github.com/erda-project/erda/pkg/envconf"
 
 // Conf action 入参
 type Conf struct {
-	TestPlan uint64 `env:"ACTION_TEST_PLAN" required:"true"`
-	Cms      string `env:"ACTION_CMS" required:"true"`
+	TestPlan      uint64 `env:"ACTION_TEST_PLAN" required:"true"`
+	Cms           string `env:"ACTION_CMS" required:"true"`
+	WaitingResult bool   `env:"ACTION_WAITING_RESULT" required:"false" default:"false"`
 	// env
 	MetaFile             string `env:"METAFILE"`
 	WorkDir              string `env:"WORKDIR" default:"."`
@@ -89,6 +90,10 @@ func TestPlan() uint64 {
 
 func Cms() string {
 	return cfg.Cms
+}
+
+func WaitingResult() bool {
+	return cfg.WaitingResult
 }
 
 func DiceClusterName() string {

--- a/actions/testplan-run/1.0/spec.yml
+++ b/actions/testplan-run/1.0/spec.yml
@@ -21,6 +21,9 @@ params:
   - name: cms
     desc: 参数配置名称
     required: true
+  - name: waiting_result
+    desc: 等待执行结果,等待 或者 不等待
+    required: false
 
 outputs:
   - name: pipelineID


### PR DESCRIPTION
add Asynchronous ability for testplan-run action

In order not to waste too much time in unimportant automated tests when executing ci/cd, asynchronous capabilities are provided

