### PR TITLE
mysql-cli remove return command run error

### DIFF
--- a/actions/mysql-cli/1.0/internal/pkg/build/execute.go
+++ b/actions/mysql-cli/1.0/internal/pkg/build/execute.go
@@ -85,7 +85,6 @@ func build(cfg conf.Conf) error {
 	err = cmd.Run()
 	if err != nil {
 		fmt.Println(fmt.Errorf("exec sql error %v", err))
-		return err
 	}
 
 	// error 信息大于 0


### PR DESCRIPTION
Returning error early will cause the error message of the mysql command to not be returned


erda-issue: [erda-issue](https://terminus-org.erda.cloud/erda/dop/projects/387/issues/bug?id=207989&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=431&type=BUG)