### PR TITLE
Added a field to continue execution after failure in testplan-action

### DIFF
--- a/actions/testplan-run/1.0/internal/conf/conf.go
+++ b/actions/testplan-run/1.0/internal/conf/conf.go
@@ -4,9 +4,9 @@ import "github.com/erda-project/erda/pkg/envconf"
 
 // Conf action 入参
 type Conf struct {
-	TestPlan      uint64 `env:"ACTION_TEST_PLAN" required:"true"`
-	Cms           string `env:"ACTION_CMS" required:"true"`
-	WaitingResult bool   `env:"ACTION_WAITING_RESULT" required:"false" default:"false"`
+	TestPlan            uint64 `env:"ACTION_TEST_PLAN" required:"true"`
+	Cms                 string `env:"ACTION_CMS" required:"true"`
+	IsContinueExecution bool   `env:"ACTION_IS_CONTINUE_EXECUTION" required:"false" default:"true"`
 	// env
 	MetaFile             string `env:"METAFILE"`
 	WorkDir              string `env:"WORKDIR" default:"."`
@@ -92,8 +92,8 @@ func Cms() string {
 	return cfg.Cms
 }
 
-func WaitingResult() bool {
-	return cfg.WaitingResult
+func IsContinueExecution() bool {
+	return cfg.IsContinueExecution
 }
 
 func DiceClusterName() string {

--- a/actions/testplan-run/1.0/spec.yml
+++ b/actions/testplan-run/1.0/spec.yml
@@ -21,8 +21,8 @@ params:
   - name: cms
     desc: 参数配置名称
     required: true
-  - name: waiting_result
-    desc: 等待执行结果,等待 或者 不等待
+  - name: is_continue_execution
+    desc: 失败后是否继续执行,执行 或者 不执行
     required: false
 
 outputs:


### PR DESCRIPTION
Added a field to continue execution after failure in testplan-action

[Test link](https://erda.dev.terminus.io/terminus/dop/projects/1/apps/3/pipeline?nodeId=MS8zL3RyZWUvZGV2ZWxvcC9waXBlbGluZS55bWw%3D&pipelineID=205)

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=216864&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDgwNSJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=506&type=BUG)