### PR TITLE
fix: herd-debian-node wrong Dockerfile path

### DIFF
--- a/dockerfiles/terminus-herd/herd.1.1.8-alpine-node.14.17/deploy.sh
+++ b/dockerfiles/terminus-herd/herd.1.1.8-alpine-node.14.17/deploy.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 image=registry.erda.cloud/erda-actions/terminus-alpine-herd:1.1.8
 

--- a/dockerfiles/terminus-herd/herd.1.1.8-debian-node.14.17/deploy.sh
+++ b/dockerfiles/terminus-herd/herd.1.1.8-debian-node.14.17/deploy.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 image=registry.erda.cloud/erda-actions/terminus-debian-herd:1.1.8-n14.17
 

--- a/dockerfiles/terminus-herd/herd.1.1.9-beta.1/deploy.sh
+++ b/dockerfiles/terminus-herd/herd.1.1.9-beta.1/deploy.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 image=registry.erda.cloud/erda-actions/terminus-herd:1.1.9-beta.1
 

--- a/dockerfiles/terminus-herd/herd.1.1.9-beta.2/deploy.sh
+++ b/dockerfiles/terminus-herd/herd.1.1.9-beta.2/deploy.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 image=registry.erda.cloud/erda-actions/terminus-herd:1.1.9-beta.2
 

--- a/dockerfiles/terminus-nodejs/node.14.17.5/deploy.sh
+++ b/dockerfiles/terminus-nodejs/node.14.17.5/deploy.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 image=registry.erda.cloud/erda-actions/terminus-debian-node:14.17-lts
 
-docker build . -t ${image}
+docker build . -t ${image} -f Dockerfile.debian.npm.6.14
 docker push ${image}
 
 echo "action meta: terminus-debian-node=$image"


### PR DESCRIPTION
- add `set -eo pipefail` shell option
- fix wrong dockerfile path of herd-debian-node