### PR TITLE
java-dependency-check: update NVD; add custom configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL=/bin/bash
 GitBranch=$(shell git rev-parse --abbrev-ref HEAD)
 GitCommit=$(shell git rev-parse --short HEAD)
 Date=$(shell date +"%Y%m%d")

--- a/actions/java-dependency-check/1.0/Dockerfile
+++ b/actions/java-dependency-check/1.0/Dockerfile
@@ -22,6 +22,7 @@ FROM registry.erda.cloud/erda/terminus-maven:3-jdk-8-alpine
 COPY --from=builder /opt/action/run /opt/action/run
 COPY --from=builder /opt/action/mvn/settings.xml /opt/action/mvn/settings.xml
 COPY --from=dcdb /usr/share/nginx/html /opt/action/dependency-check
+RUN mvn org.owasp:dependency-check-maven:6.3.1:update-only -DdataDirectory=/opt/action/dependency-check
 
 
 CMD ["/opt/action/run"]

--- a/actions/java-dependency-check/1.0/internal/pkg/build/execute.go
+++ b/actions/java-dependency-check/1.0/internal/pkg/build/execute.go
@@ -26,7 +26,7 @@ func Execute() error {
 	return nil
 }
 
-const (
+var (
 	mvnSettingsXMLFilePath = "/opt/action/mvn/settings.xml"
 )
 
@@ -41,6 +41,10 @@ func scan(cfg conf.Conf) error {
 	}
 
 	// render mvn settings.xml
+	if len(cfg.MavenSettingsXMLPath) > 0 {
+		fmt.Fprintf(os.Stdout, "use use specified maven settings file: %s\n", cfg.MavenSettingsXMLPath)
+		mvnSettingsXMLFilePath = cfg.MavenSettingsXMLPath
+	}
 	if err := render.RenderTemplate(filepath.Dir(mvnSettingsXMLFilePath), map[string]string{
 		"NEXUS_URL":      cfg.NexusURL,
 		"NEXUS_USERNAME": cfg.NexusUsername,

--- a/actions/java-dependency-check/1.0/internal/pkg/build/execute.go
+++ b/actions/java-dependency-check/1.0/internal/pkg/build/execute.go
@@ -86,7 +86,9 @@ func scan(cfg conf.Conf) error {
 	}
 
 	// copy result to uploadDir
-	if output, err := exec.Command("/bin/sh", "-c", "cp target/dependency-check-* "+cfg.UploadDir).CombinedOutput(); err != nil {
+	targetUploadDir := filepath.Join(cfg.UploadDir, "result")
+	copyCmd := fmt.Sprintf("mkdir -p %s; cp -a target/. %s", targetUploadDir, targetUploadDir)
+	if output, err := exec.Command("/bin/bash", "-c", copyCmd).CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to copy report for download, err: %v, output: %s", err, string(output))
 	}
 

--- a/actions/java-dependency-check/1.0/internal/pkg/conf/conf.go
+++ b/actions/java-dependency-check/1.0/internal/pkg/conf/conf.go
@@ -13,8 +13,9 @@ type Conf struct {
 	Memory float64 `env:"PIPELINE_LIMITED_MEM"`
 
 	// 用户指定
-	CodeDir            string `env:"ACTION_CODE_DIR" required:"true"`
-	Debug              bool   `env:"ACTION_DEBUG" default:"false"`
-	AutoUpdateNVD      bool   `env:"ACTION_AUTO_UPDATE_NVD" default:"false"`
-	MavenPluginVersion string `env:"ACTION_MAVEN_PLUGIN_VERSION" default:"6.3.1"`
+	CodeDir              string `env:"ACTION_CODE_DIR" required:"true"`
+	Debug                bool   `env:"ACTION_DEBUG" default:"false"`
+	AutoUpdateNVD        bool   `env:"ACTION_AUTO_UPDATE_NVD" default:"false"`
+	MavenPluginVersion   string `env:"ACTION_MAVEN_PLUGIN_VERSION" default:"6.3.1"`
+	MavenSettingsXMLPath string `env:"ACTION_MAVEN_SETTINGS_XML_PATH" required:"false"`
 }

--- a/actions/java-dependency-check/1.0/internal/pkg/conf/conf.go
+++ b/actions/java-dependency-check/1.0/internal/pkg/conf/conf.go
@@ -12,8 +12,9 @@ type Conf struct {
 
 	Memory float64 `env:"PIPELINE_LIMITED_MEM"`
 
-	Debug bool `env:"DEBUG" default:"false"`
-
 	// 用户指定
-	CodeDir string `env:"ACTION_CODE_DIR" required:"true"`
+	CodeDir            string `env:"ACTION_CODE_DIR" required:"true"`
+	Debug              bool   `env:"ACTION_DEBUG" default:"false"`
+	AutoUpdateNVD      bool   `env:"ACTION_AUTO_UPDATE_NVD" default:"false"`
+	MavenPluginVersion string `env:"ACTION_MAVEN_PLUGIN_VERSION" default:"6.3.1"`
 }

--- a/actions/java-dependency-check/1.0/spec.yml
+++ b/actions/java-dependency-check/1.0/spec.yml
@@ -31,3 +31,6 @@ params:
     desc: 用于漏洞扫描的 Maven 插件版本。可以通过 https://jeremylong.github.io/DependencyCheck/dependency-check-maven/index.html 获取最新版本。
     required: false
     default: "6.3.1"
+  - name: maven_settings_xml_path
+    type: string
+    desc: 用户自定义的 Maven 配置文件路径。若未指定，则使用内置的配置文件。

--- a/actions/java-dependency-check/1.0/spec.yml
+++ b/actions/java-dependency-check/1.0/spec.yml
@@ -16,3 +16,18 @@ params:
     type: string
     desc: 代码目录，例如 ${git-checkout}
     required: true
+  - name: debug
+    type: bool
+    desc: 打开插件调试模式，显示更多日志
+    required: false
+    default: false
+  - name: auto_update_nvd
+    type: bool
+    desc: 自动更新 NVD 漏洞数据库；内置数据库已为最新，一般情况下无需打开该选项。该选项需要联网，网络不畅会导致更新失败。
+    required: false
+    default: false
+  - name: maven_plugin_version
+    type: string
+    desc: 用于漏洞扫描的 Maven 插件版本。可以通过 https://jeremylong.github.io/DependencyCheck/dependency-check-maven/index.html 获取最新版本。
+    required: false
+    default: "6.3.1"


### PR DESCRIPTION
## Description

fix java-dependency-check:

- update NVD using maven plugin's update-only phrase
- add some useful action params, such as debug mode, maven plugin version, auto update NVD, etc
- fix upload limitation to /api/files. `.html` is forbidden, so use one tar for all reports.

Tested in HKCI and Roche and works fine.

![image](https://user-images.githubusercontent.com/13919034/132832573-851ce572-d2e5-456d-bee0-a628ce938671.png)


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
