### PR TITLE
android release bugfix

### DIFF
--- a/actions/release/1.0/Dockerfile
+++ b/actions/release/1.0/Dockerfile
@@ -13,9 +13,11 @@ RUN mkdir -p /opt/action/comp/migration/sql && \
 RUN set -x \
     	&& eval "GOOS=linux GOARCH=amd64 go build $BUILD_FLAGS -o /assets/run github.com/erda-project/erda-actions/actions/release/1.0/internal/cmd"
 
-FROM docker:latest AS action
+FROM registry.erda.cloud/erda/terminus-alpine:base
+
 RUN echo "http://mirrors.aliyun.com/alpine/v3.12/main/" > /etc/apk/repositories && \
-    echo "http://mirrors.aliyun.com/alpine/v3.12/community/" >> /etc/apk/repositories
+    echo "http://mirrors.aliyun.com/alpine/v3.12/community/" >> /etc/apk/repositories && \
+    apk update && apk add --no-cache docker
 RUN apk add --no-cache bash tar
 
 COPY --from=builder /assets /opt/action

--- a/actions/release/1.0/dice.yml
+++ b/actions/release/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   release:
-    image: registry.erda.cloud/erda-actions/release-action:20210915-f80e952
+    image: registry.erda.cloud/erda-actions/release-action:1.0-20210918-521bcf8
     envs:
       BASE64_SWITCH: false
     resources:

--- a/actions/release/1.0/internal/cmd/main.go
+++ b/actions/release/1.0/internal/cmd/main.go
@@ -10,6 +10,7 @@ import (
 func main() {
 	if err := pkg.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		fmt.Println(fmt.Sprintf("err info: %v", err))
 		os.Exit(1)
 	}
 }

--- a/actions/release/1.0/internal/conf/conf.go
+++ b/actions/release/1.0/internal/conf/conf.go
@@ -1,5 +1,10 @@
 package conf
 
+import (
+	"encoding/json"
+	"strconv"
+)
+
 // Conf action 入参
 type Conf struct {
 	WorkDir  string `env:"WORKDIR"`
@@ -75,4 +80,25 @@ type AABInfo struct {
 	PackageName interface{} `json:"packageName"`
 	VersionCode interface{} `json:"versionCode"`
 	VersionName interface{} `json:"versionName"`
+}
+
+func (s AABInfo) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+func (s *AABInfo) UnmarshalJSON(data []byte) error {
+	var aABInfoAdaptor AABInfoAdaptor
+	err := json.Unmarshal(data, &aABInfoAdaptor)
+	if err == nil {
+		s.PackageName = aABInfoAdaptor.PackageName
+		s.VersionCode = strconv.FormatInt(aABInfoAdaptor.VersionCode, 10)
+		s.VersionName = aABInfoAdaptor.VersionName
+	}
+	return nil
+}
+
+type AABInfoAdaptor struct {
+	PackageName string `json:"packageName"`
+	VersionCode int64  `json:"versionCode"`
+	VersionName string `json:"versionName"`
 }

--- a/actions/release/1.0/internal/conf/conf.go
+++ b/actions/release/1.0/internal/conf/conf.go
@@ -1,10 +1,5 @@
 package conf
 
-import (
-	"encoding/json"
-	"strconv"
-)
-
 // Conf action 入参
 type Conf struct {
 	WorkDir  string `env:"WORKDIR"`
@@ -80,25 +75,4 @@ type AABInfo struct {
 	PackageName interface{} `json:"packageName"`
 	VersionCode interface{} `json:"versionCode"`
 	VersionName interface{} `json:"versionName"`
-}
-
-func (s AABInfo) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s)
-}
-
-func (s *AABInfo) UnmarshalJSON(data []byte) error {
-	var aABInfoAdaptor AABInfoAdaptor
-	err := json.Unmarshal(data, &aABInfoAdaptor)
-	if err == nil {
-		s.PackageName = aABInfoAdaptor.PackageName
-		s.VersionCode = strconv.FormatInt(aABInfoAdaptor.VersionCode, 10)
-		s.VersionName = aABInfoAdaptor.VersionName
-	}
-	return nil
-}
-
-type AABInfoAdaptor struct {
-	PackageName string `json:"packageName"`
-	VersionCode int64  `json:"versionCode"`
-	VersionName string `json:"versionName"`
 }

--- a/actions/release/1.0/internal/pkg/execute.go
+++ b/actions/release/1.0/internal/pkg/execute.go
@@ -55,7 +55,6 @@ func Execute() error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("release check 2")
 	//image和services是release的两种模式，一种是用户传入image，然后release做些其他处理，
 	//一种就是传入service，然后release根据配置进行构建出imageAddr, 然后把imageAddr设置进images属性中
 	//这里就是新加的service，根据service构建，然后塞入image中
@@ -74,7 +73,6 @@ func Execute() error {
 	}
 
 	if cfg.ReleaseMobile != nil {
-		fmt.Println("release check 3")
 		var typeCounts int
 		// 移动应用文件资源
 		// 一次release只能release一种类型的移动应用
@@ -141,7 +139,6 @@ func Execute() error {
 				}
 				req.Version = version
 			}
-			fmt.Println("release check 4")
 			// TODO Change get information from configuration to extract from abb file
 			if resourceType == apistructs.ResourceTypeAndroidAppBundle {
 				// info, err := GetAndroidAppBundleInfo(appFilePath)
@@ -206,7 +203,6 @@ func Execute() error {
 				}
 				req.Version = version
 			}
-			fmt.Println("release check 5")
 			if resourceType == apistructs.ResourceTypeH5 {
 				var h5VersionInfo apistructs.H5VersionInfo
 				f, err := ioutil.ReadFile(appFilePath + "/mobileBuild.cfg")
@@ -256,7 +252,6 @@ func Execute() error {
 			})
 		}
 	}
-	fmt.Println("release check 6")
 	// 填充 dice.yml(合并对应环境dice.yml & 填充dice.yml镜像)
 	diceYml, err := fillDiceYml(&cfg, storage)
 	if err != nil && cfg.ReleaseMobile == nil {
@@ -294,7 +289,6 @@ func Execute() error {
 	if err = ioutil.WriteFile("dicehub_release", []byte(releaseID), 0644); err != nil {
 		return errors.Wrap(err, "failed to store release id")
 	}
-	fmt.Println("release check 7")
 	// write metafile
 	metaInfos := make([]apistructs.MetadataField, 0, 1)
 	metaInfos = append(metaInfos, apistructs.MetadataField{

--- a/actions/release/1.0/internal/pkg/execute.go
+++ b/actions/release/1.0/internal/pkg/execute.go
@@ -32,7 +32,6 @@ const (
 
 // Execute release action 执行逻辑
 func Execute() error {
-	//time.Sleep(time.Minute*30)
 	logrus.SetOutput(os.Stdout)
 
 	var cfg conf.Conf
@@ -56,7 +55,7 @@ func Execute() error {
 	if err != nil {
 		return err
 	}
-
+	fmt.Println("release check 2")
 	//image和services是release的两种模式，一种是用户传入image，然后release做些其他处理，
 	//一种就是传入service，然后release根据配置进行构建出imageAddr, 然后把imageAddr设置进images属性中
 	//这里就是新加的service，根据service构建，然后塞入image中
@@ -71,10 +70,11 @@ func Execute() error {
 			return err
 		}
 		req.Resources = releaseResources
-		logrus.Infof("uploaded release resources: %+v", releaseResources)
+		fmt.Println(fmt.Sprintf("uploaded release resources: %+v", releaseResources))
 	}
 
 	if cfg.ReleaseMobile != nil {
+		fmt.Println("release check 3")
 		var typeCounts int
 		// 移动应用文件资源
 		// 一次release只能release一种类型的移动应用
@@ -141,7 +141,7 @@ func Execute() error {
 				}
 				req.Version = version
 			}
-
+			fmt.Println("release check 4")
 			// TODO Change get information from configuration to extract from abb file
 			if resourceType == apistructs.ResourceTypeAndroidAppBundle {
 				// info, err := GetAndroidAppBundleInfo(appFilePath)
@@ -206,7 +206,7 @@ func Execute() error {
 				}
 				req.Version = version
 			}
-
+			fmt.Println("release check 5")
 			if resourceType == apistructs.ResourceTypeH5 {
 				var h5VersionInfo apistructs.H5VersionInfo
 				f, err := ioutil.ReadFile(appFilePath + "/mobileBuild.cfg")
@@ -226,7 +226,7 @@ func Execute() error {
 				if err != nil {
 					return err
 				}
-				logrus.Infof("H5VersionInfo is %v", h5VersionInfo)
+				fmt.Println(fmt.Sprintf("H5VersionInfo is %v", h5VersionInfo))
 
 				version := h5VersionInfo.Version
 				buildID := h5VersionInfo.BuildID
@@ -256,14 +256,14 @@ func Execute() error {
 			})
 		}
 	}
-
+	fmt.Println("release check 6")
 	// 填充 dice.yml(合并对应环境dice.yml & 填充dice.yml镜像)
 	diceYml, err := fillDiceYml(&cfg, storage)
 	if err != nil && cfg.ReleaseMobile == nil {
 		return err
 	}
 	req.Dice = diceYml
-	logrus.Infof("composed & filled dice.yml: %v", req.Dice)
+	fmt.Println(fmt.Sprintf("composed & filled dice.yml: %v", req.Dice))
 
 	// migration sql release
 	migrationReleaseID, err := migration(&cfg)
@@ -288,13 +288,13 @@ func Execute() error {
 	if err != nil {
 		return err
 	}
-	logrus.Infof("releaseId: %s", releaseID)
+	fmt.Println(fmt.Sprintf("releaseId: %s", releaseID))
 
 	// create dicehub_release file in nfs, store releaseID
 	if err = ioutil.WriteFile("dicehub_release", []byte(releaseID), 0644); err != nil {
 		return errors.Wrap(err, "failed to store release id")
 	}
-
+	fmt.Println("release check 7")
 	// write metafile
 	metaInfos := make([]apistructs.MetadataField, 0, 1)
 	metaInfos = append(metaInfos, apistructs.MetadataField{

--- a/actions/release/1.0/spec.yml
+++ b/actions/release/1.0/spec.yml
@@ -72,11 +72,17 @@ params:
   - name: services
     type: map
     desc: 项目基于那个镜像运行，运行命令是什么
-  
+
   - name: aab_info
     type: map
     desc: 等做完 aab 里的 AndroidManifest.xml 解析后，可删除该参数
     required: false
+  - name: release_mobile
+    type: struct
+    desc: 移动端打包
+    struct:
+      - {name: files, type: string_array, desc: 打包文件 }
+      - {name: version, type: string, desc: 版本 }
 
 accessibleAPIs:
   # push release


### PR DESCRIPTION
## Description
The graphical interface will lose release_mobile. The reason for the loss of the release_mobile field should be that the graphical editing interface is used, which does not have this field on the graphical interface.


erda-issue: [erda-issue](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=226639&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1MDZdLCJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDU2MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG)

## Checklist

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
