### PR TITLE
set innodb options in my.cnf on sandbox mysql 5.6

### DIFF
--- a/actions/erda-mysql-migration/1.0-56/Dockerfile
+++ b/actions/erda-mysql-migration/1.0-56/Dockerfile
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 RUN chmod 777 /opt/action/run
 RUN chmod 777 /opt/action/erda-migrate
 
-FROM erdaproject/erda-mysql-migration-sandbox56:20210916
+FROM erdaproject/erda-mysql-migration-sandbox56:20210922
 
 MAINTAINER chenzhongrun "zhongrun.czr@alibaba-inc.com"
 

--- a/actions/erda-mysql-migration/1.0-56/dice.yml
+++ b/actions/erda-mysql-migration/1.0-56/dice.yml
@@ -13,7 +13,7 @@
 
 jobs:
   erda-mysql-migration:
-    image: registry.erda.cloud/erda-actions/erda-mysql-migration-action:1.0-56-20210918-21fcdad
+    image: registry.erda.cloud/erda-actions/erda-mysql-migration-action:1.0-56-20210922-3ce8143
     resource:
       cpu: 0.5
       disk: 1024

--- a/actions/erda-mysql-migration/1.0-56/dice.yml
+++ b/actions/erda-mysql-migration/1.0-56/dice.yml
@@ -13,7 +13,7 @@
 
 jobs:
   erda-mysql-migration:
-    image: registry.erda.cloud/erda-actions/erda-mysql-migration-action:1.0-56-20210917-2b2c99c
+    image: registry.erda.cloud/erda-actions/erda-mysql-migration-action:1.0-56-20210918-21fcdad
     resource:
       cpu: 0.5
       disk: 1024

--- a/dockerfiles/erda-migration/sandbox56/Dockerfile
+++ b/dockerfiles/erda-migration/sandbox56/Dockerfile
@@ -8,7 +8,7 @@ ENV TZ=Asia/Shanghai
 ENV MYSQL_ROOT_PASSWORD="12345678"
 ENV MYSQL_ALLOW_EMPTY_PASSWORD yes
 
-COPY dockerfiles/erda-migration/my.cnf /etc/my.cnf
+COPY dockerfiles/erda-migration/sandbox56/my.cnf /etc/my.cnf
 
 # install python3
 RUN yum install -y mariadb-devel gcc python3-devel.x86_64

--- a/dockerfiles/erda-migration/sandbox56/my.cnf
+++ b/dockerfiles/erda-migration/sandbox56/my.cnf
@@ -1,0 +1,12 @@
+[client]
+default-character-set=utf8mb4
+
+[mysqld]
+user=mysql
+symbolic-links = 0
+skip_name_resolve
+innodb_file_format = barracuda
+innodb_file_per_table = on
+innodb_large_prefix = on
+
+!includedir /etc/my.cnf.d


### PR DESCRIPTION
## Description

set innodb options in my.cnf on sandbox mysql 5.6
```text
innodb_file_format = barracuda
innodb_file_per_table = on
innodb_large_prefix = on
```

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [ ] My change is adequately tested.
