### PR TITLE
Upgrade git checkout openssl

### DIFF
--- a/actions/git-checkout/1.0/Dockerfile
+++ b/actions/git-checkout/1.0/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:3.8 AS tunnelbuilder
-RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main/" > /etc/apk/repositories && \
-    echo "http://mirrors.aliyun.com/alpine/v3.8/community/" >> /etc/apk/repositories
+FROM alpine:3.14 AS tunnelbuilder
 RUN apk --no-cache add git make gcc g++ libressl-dev
 
 WORKDIR /root
@@ -9,9 +7,7 @@ RUN git clone https://github.com/proxytunnel/proxytunnel.git
 WORKDIR /root/proxytunnel
 RUN make
 
-FROM alpine:3.8 AS resource
-RUN echo "http://mirrors.aliyun.com/alpine/v3.8/main/" > /etc/apk/repositories && \
-    echo "http://mirrors.aliyun.com/alpine/v3.8/community/" >> /etc/apk/repositories
+FROM alpine:3.14 AS resource
 
 RUN apk --no-cache add \
   bash \

--- a/actions/git-checkout/1.0/dice.yml
+++ b/actions/git-checkout/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   git-checkout:
-    image: registry.erda.cloud/erda-actions/git-checkout-action:20210720-badf994
+    image: registry.erda.cloud/erda-actions/git-checkout-action:1.0-20211003-2e74390
     resources:
       cpu: 0.5
       mem: 1024


### PR DESCRIPTION
## Description

https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/

![image](https://user-images.githubusercontent.com/13919034/135743810-453c480f-3872-471c-8d91-58bf665d8718.png)

```text
Unfortunately this does not apply to OpenSSL 1.0.2 which always prefers the untrusted chain and if that chain contains a path that leads to an expired trusted root certificate (DST Root CA X3), it will be selected for the certificate verification and the expiration will be reported.
```

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
