### PR TITLE
fix: git-checkout action downgrade base alpine version from 3.14 to 3.12 to fix dns issue

### DIFF
--- a/actions/git-checkout/1.0/Dockerfile
+++ b/actions/git-checkout/1.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14 AS tunnelbuilder
+FROM alpine:3.12 AS tunnelbuilder
 RUN apk --no-cache add git make gcc g++ libressl-dev
 
 WORKDIR /root

--- a/actions/git-checkout/1.0/dice.yml
+++ b/actions/git-checkout/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   git-checkout:
-    image: registry.erda.cloud/erda-actions/git-checkout-action:1.0-20211003-2e74390
+    image: registry.erda.cloud/erda-actions/git-checkout-action:1.0-20211103-64dee96
     resources:
       cpu: 0.5
       mem: 1024


### PR DESCRIPTION
## Description

[Related Erda Issue](https://erda.cloud/erda/dop/projects/387/issues/all?id=243046&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyI5MiJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=467&type=TASK)

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
