### PR TITLE
fix: git-checkout action downgrade alpine version for dns issue

### DIFF
--- a/actions/git-checkout/1.0/Dockerfile
+++ b/actions/git-checkout/1.0/Dockerfile
@@ -7,7 +7,7 @@ RUN git clone https://github.com/proxytunnel/proxytunnel.git
 WORKDIR /root/proxytunnel
 RUN make
 
-FROM alpine:3.14 AS resource
+FROM alpine:3.12 AS resource
 
 RUN apk --no-cache add \
   bash \

--- a/actions/git-checkout/1.0/dice.yml
+++ b/actions/git-checkout/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   git-checkout:
-    image: registry.erda.cloud/erda-actions/git-checkout-action:1.0-20211103-64dee96
+    image: registry.erda.cloud/erda-actions/git-checkout-action:1.0-20211103-d346e63
     resources:
       cpu: 0.5
       mem: 1024


### PR DESCRIPTION
## Description

[previous pr](https://github.com/erda-project/erda-actions/pull/248) missing second alpine version replace in Dockerfile.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
