### PR TITLE
java-action: Dockerfile openjfx8 use registry.erda.cloud

### DIFF
--- a/actions/java/1.0/Dockerfile
+++ b/actions/java/1.0/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p /opt/action/comp && \
 RUN bash /opt/action/comp/download_spot_agent.sh
 RUN bash /opt/action/comp/download_fonts.sh
 
-FROM yannishuber/openjfx8 AS openjfx
+FROM registry.erda.cloud/retag/yannishuber-openjfx8:v1 AS openjfx
 
 FROM registry.erda.cloud/erda/terminus-openjdk:v11.0.6
 


### PR DESCRIPTION
## Description

use registry.erda.cloud for openjfx8

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
