### PR TITLE
ios upload file timeout time set

### DIFF
--- a/actions/ios/1.0/dice.yml
+++ b/actions/ios/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   ios:
-    image: registry.erda.cloud/erda-actions/ios-action:20210323-a63216bd
+    image: registry.erda.cloud/erda-actions/ios-action:1.0-20211126-b1e6d0b
     resources:
       cpu: 1
       mem: 1024

--- a/actions/ios/1.0/internal/pkg/build/build.go
+++ b/actions/ios/1.0/internal/pkg/build/build.go
@@ -85,8 +85,11 @@ func Execute() error {
 	// 打包本地context环境
 	logrus.Infof("package local context tar")
 	os.Chdir(cfg.PipelineContext)
-
-	err := Tar(localTarFilePath, ".")
+	err := runCommand("rm ", "-rf", ".git")
+	if err != nil {
+		fmt.Printf("remove .git dir error %v", err)
+	}
+	err = Tar(localTarFilePath, ".")
 	if err != nil {
 		return err
 	}

--- a/pkg/dice/file_upload.go
+++ b/pkg/dice/file_upload.go
@@ -36,7 +36,7 @@ func UploadFile(req *UploadFileRequest) (*apistructs.FileUploadResponse, error) 
 		},
 	}
 	var resp apistructs.FileUploadResponse
-	request := httpclient.New(httpclient.WithCompleteRedirect()).Post(req.OpenApiPrefix).
+	request := httpclient.New(httpclient.WithCompleteRedirect(), httpclient.WithTimeout(3*httpclient.DialTimeout, 3*httpclient.ClientDefaultTimeout)).Post(req.OpenApiPrefix).
 		Path("/api/files").
 		Param("fileFrom", req.From).
 		Param("expiredIn", req.ExpireIn).


### PR DESCRIPTION
## Description

The ios task timed out when uploading files, the reason is that there are .git files in the compressed files

## Checklist

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
