### PR TITLE
fix: The mysql password has special characters, causing the connection to mysql to fail

### DIFF
--- a/actions/mysql-assert/1.0/dice.yml
+++ b/actions/mysql-assert/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   mysql-assert:
-    image: registry.erda.cloud/erda-actions/mysql-assert-action:20210910-713594b
+    image: registry.erda.cloud/erda-actions/mysql-assert-action:1.0-20220121-315b79c
     envs:
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud
     resources:

--- a/actions/mysql-assert/1.0/internal/pkg/build/execute.go
+++ b/actions/mysql-assert/1.0/internal/pkg/build/execute.go
@@ -79,7 +79,7 @@ func build(cfg conf.Conf) error {
 		return err
 	}
 
-	cmd := exec.Command("/bin/sh", "-c", "mysqlsh --json=raw --host="+mysqlAddon.Config[mysqlHost].(string)+" --password="+mysqlAddon.Config[mysqlPassword].(string)+" "+
+	cmd := exec.Command("/bin/sh", "-c", "mysqlsh --json=raw --host="+mysqlAddon.Config[mysqlHost].(string)+" --password='"+mysqlAddon.Config[mysqlPassword].(string)+"' "+
 		"--dbuser="+mysqlAddon.Config[mysqlUsername].(string)+" --port="+mysqlAddon.Config[mysqlPort].(string)+" --database="+cfg.Database+" --file=mysql-cli.sql")
 
 	var output bytes.Buffer

--- a/actions/mysql-cli/1.0/dice.yml
+++ b/actions/mysql-cli/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   mysql-cli:
-    image: registry.erda.cloud/erda-actions/mysql-cli-action:20210817-b275aad
+    image: registry.erda.cloud/erda-actions/mysql-cli-action:1.0-20220121-315b79c
     envs:
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud
     resources:

--- a/actions/mysql-cli/1.0/internal/pkg/build/execute.go
+++ b/actions/mysql-cli/1.0/internal/pkg/build/execute.go
@@ -75,7 +75,7 @@ func build(cfg conf.Conf) error {
 		return err
 	}
 
-	cmd := exec.Command("/bin/sh", "-c", "mysqlsh --json=raw --host="+mysqlAddon.Config[mysqlHost].(string)+" --password="+mysqlAddon.Config[mysqlPassword].(string)+" "+
+	cmd := exec.Command("/bin/sh", "-c", "mysqlsh --json=raw --host="+mysqlAddon.Config[mysqlHost].(string)+" --password='"+mysqlAddon.Config[mysqlPassword].(string)+"' "+
 		"--dbuser="+mysqlAddon.Config[mysqlUsername].(string)+" --port="+mysqlAddon.Config[mysqlPort].(string)+" --database="+cfg.Database+" --file=mysql-cli.sql")
 
 	var output bytes.Buffer


### PR DESCRIPTION
## Description
The mysql password has special characters, causing the connection to mysql to fail

## Checklist


 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
