### PR TITLE
fix: typo of redis-cli action params

### DIFF
--- a/actions/redis-cli/1.0/spec.yml
+++ b/actions/redis-cli/1.0/spec.yml
@@ -32,7 +32,7 @@ formProps:
     group: params
     componentProps:
       title: ${{ i18n.formProps.params.componentProps.title }}
-  - label: datasource`
+  - label: datasource
     component: dataSourceSelector
     required: true
     key: params.datasource


### PR DESCRIPTION
## Description

typo of redis-cli action params

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
