### PR TITLE
feat: udpate erda-mysql-migration images: use character set utf8 in sandbox

### DIFF
--- a/actions/erda-mysql-migration/1.0-56/dice.yml
+++ b/actions/erda-mysql-migration/1.0-56/dice.yml
@@ -13,7 +13,7 @@
 
 jobs:
   erda-mysql-migration:
-    image: registry.erda.cloud/erda-actions/erda-mysql-migration-action:1.0-56-20220221-8938137
+    image: registry.erda.cloud/erda-actions/erda-mysql-migration-action:1.0-56-20220224-9c56022
     resource:
       cpu: 0.5
       disk: 1024

--- a/actions/erda-mysql-migration/1.0-57/dice.yml
+++ b/actions/erda-mysql-migration/1.0-57/dice.yml
@@ -13,7 +13,7 @@
 
 jobs:
   erda-mysql-migration:
-    image: registry.erda.cloud/erda-actions/erda-mysql-migration-action:1.0-57-20220221-8938137
+    image: registry.erda.cloud/erda-actions/erda-mysql-migration-action:1.0-57-20220224-9c56022
     resource:
       cpu: 0.5
       disk: 1024

--- a/actions/erda-mysql-migration/1.0-80/dice.yml
+++ b/actions/erda-mysql-migration/1.0-80/dice.yml
@@ -13,7 +13,7 @@
 
 jobs:
   erda-mysql-migration:
-    image: registry.erda.cloud/erda-actions/erda-mysql-migration-action:1.0-80-20220221-8938137
+    image: registry.erda.cloud/erda-actions/erda-mysql-migration-action:1.0-80-20220224-9c56022
     resource:
       cpu: 0.5
       disk: 1024


### PR DESCRIPTION
## Description
feat: udpate erda-mysql-migration images: use character set utf8 in sandbox

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [ ] My change is adequately tested.
