### PR TITLE
fix(js-build): update node version and support node@16

### DIFF
--- a/actions/js-build/1.0/Dockerfile
+++ b/actions/js-build/1.0/Dockerfile
@@ -9,8 +9,8 @@ SHELL ["/bin/bash", "--login", "-c"]
 
 RUN yum -y install gcc bzip2 git
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 
-RUN nvm install v12.22.5 && nvm install v14.17.5 &&  nvm install v8.17.0 && nvm install v10.24.1 &&  nvm use v12.22.5
+RUN nvm install 12 && nvm install 14 &&  nvm install 16 && nvm install 8 && nvm install 10 && nvm use 12
 
 RUN npm install webpack -g && npm install webpack-cli -g && npm install -g cnpm --registry=https://registry.npmmirror.com

--- a/actions/js-build/1.0/README.md
+++ b/actions/js-build/1.0/README.md
@@ -1,6 +1,13 @@
 ### js-build Action
 
-Warning!!! 当前为 Beta 版，不推荐使用，不向前兼容。
+
+#### Params
+
+| 属性 | 说明 | 默认值 |
+|----|---|---|
+| node_version| 特殊指定运行的 node 版本| 12 |
+| build_cmd | 需要执行的 sh 命令| -|
+| workdir | 指定执行命令的文件目录 | - |
 
 例子:
 

--- a/actions/js-build/1.0/internal/pkg/build/execute.go
+++ b/actions/js-build/1.0/internal/pkg/build/execute.go
@@ -15,10 +15,11 @@ import (
 )
 
 var SupportNodeVersionFormatMap = map[string]string{
-	"8":  "v8.17.0",
-	"10": "v10.24.1",
-	"12": "v12.22.5",
-	"14": "v14.17.5",
+	"8":  "8",
+	"10": "10",
+	"12": "12",
+	"14": "14",
+	"16": "16"
 }
 
 func Execute() error {

--- a/actions/js-build/1.0/internal/pkg/conf/conf.go
+++ b/actions/js-build/1.0/internal/pkg/conf/conf.go
@@ -1,6 +1,6 @@
 package conf
 
-// Conf js action param collection
+// Conf js build action param collection
 type Conf struct {
 	MetaFile string `env:"METAFILE"`
 	WorkDir  string `env:"WORKDIR"`


### PR DESCRIPTION
## Description

update node version which is builtin under js-build action and add node@16 for config


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [ ] My change is adequately tested.
