### PR TITLE
fix: action agent blocked due to stdout log

### DIFF
--- a/actions/agent/1.0/dice.yml
+++ b/actions/agent/1.0/dice.yml
@@ -1,10 +1,10 @@
 ### job 配置项
 jobs:
   agent:
-    image: registry.erda.cloud/erda-actions/action-agent:2.2-alpha-20220507134854-9116bec47
+    image: registry.erda.cloud/erda-actions/action-agent:2.2-alpha-20220606145943-831627f7a
     labels:
       # 必填字段
-      MD5: f693a2b66edf1eb2cd8ebeecfce84bb6
+      MD5: e598a65e519e389b7af912d9210f267a
     envs:
       # DEBUG mode, will produce more logs
       DEBUG: false


### PR DESCRIPTION
## Description
fix action agent blocked due to stdout log

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [ ] My change is adequately tested.
