### PR TITLE
fix: expand resource of loop action

### DIFF
--- a/actions/loop/1.0/dice.yml
+++ b/actions/loop/1.0/dice.yml
@@ -2,6 +2,6 @@ jobs:
   loop:
     image: registry.erda.cloud/erda-actions/loop-action:20200710-d0aace2
     resources:
-      cpu: 0.01
-      mem: 32
+      cpu: 0.1
+      mem: 128
       disk: 0


### PR DESCRIPTION
## Description
expand resource of loop action, because 32 mem may cause oomkilled

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [ ] My change is adequately tested.
