### PR TITLE
feat: set `max_old_space_size` option for js-build action

### DIFF
--- a/actions/js-build/1.0/dice.yml
+++ b/actions/js-build/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   js-build:
-    image: registry.erda.cloud/erda-actions/js-build-action:1.0-20230427162436-685950d
+    image: registry.erda.cloud/erda-actions/js-build-action:1.0-20230710105441-b9ad3492
     envs:
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud
     resources:

--- a/actions/js-build/1.0/internal/pkg/build/execute.go
+++ b/actions/js-build/1.0/internal/pkg/build/execute.go
@@ -117,6 +117,12 @@ func runCommand(cmd string) error {
 	command := exec.Command("/bin/bash", "-c", cmd)
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr
+	memory := os.Getenv("PIPELINE_LIMITED_MEM")
+	if memory == "" {
+		memory = "2048"
+	}
+	command.Env = append(command.Environ(), fmt.Sprintf("NODE_OPTIONS=--max-old-space-size=%s",
+		memory))
 	if err := command.Run(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

set `max_old_space_size` option for js-build action

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [ ] My change is adequately tested.
