### PR TITLE
fix: remove useless TARGETPLATFORM arguement in comp dockerfile

### DIFF
--- a/actions/golang/1.0/comp/Dockerfile
+++ b/actions/golang/1.0/comp/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM registry.erda.cloud/erda/terminus-golang:1.19.7
+FROM registry.erda.cloud/erda/terminus-golang:1.19.7
 
 ARG TARGET
 

--- a/actions/golang/1.0/dice.yml
+++ b/actions/golang/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   golang:
-    image: registry.erda.cloud/erda-actions/golang-action:1.0-20230427153900-685950d
+    image: registry.erda.cloud/erda-actions/golang-action:1.0-20230818184443-368edf36
     resources:
       cpu: 0.5
       mem: 1024


### PR DESCRIPTION
## Description
remove useless TARGETPLATFORM arguement in comp dockerfile, because docker engine does not automatically stuff this arguement


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
