### PR TITLE
chore: Update default node version to v18 for js-build 2.0 Action

### DIFF
--- a/actions/js-build/2.0/README.md
+++ b/actions/js-build/2.0/README.md
@@ -1,1 +1,68 @@
-../1.0/README.md
+### js-build Action
+
+#### Params
+
+| 属性         | 说明                     | 默认值 |
+| ------------ | ------------------------ | ------ |
+| node_version | 特殊指定运行的 node 版本 | 18     |
+| build_cmd    | 需要执行的 sh 命令       | -      |
+| workdir      | 指定执行命令的文件目录   | -      |
+
+例子:
+
+```yaml
+- js-build:
+    alias: js-build
+    version: "2.0"
+    params:
+      node_version: 18
+      build_cmd:
+        - npm config set registry=https://registry.npm.terminus.io/ && npm i
+        - npm run build
+      workdir: ${git-checkout}
+```
+
+```yaml
+- js-build:
+    alias: js-build
+    version: "2.0"
+    params:
+      build_cmd:
+        - cnpm i
+      workdir: ${git-checkout}
+```
+
+### release 用例
+
+herd 模式
+
+```yaml
+- release:
+    alias: release
+    params:
+      dice_yml: ${git-checkout}/dice.yml
+      services:
+        js-demo:
+          cmd: cd /root/js-build && ls && npm run dev
+          copys:
+            - ${js-build}:/root/
+          image: registry.erda.cloud/erda-actions/terminus-herd:1.1.8-node12
+```
+
+spa 模式
+
+```yaml
+- release:
+    alias: release
+    params:
+      dice_yml: ${git-checkout}/dice.yml
+      services:
+        js-demo:
+          # 固定值，前提是项目中有 nginx.conf.template
+          cmd: sed -i "s^server_name .*^^g" /etc/nginx/conf.d/nginx.conf.template && envsubst "`printf '$%s' $(bash -c "compgen -e")`" < /etc/nginx/conf.d/nginx.conf.template > /etc/nginx/conf.d/default.conf && /usr/local/openresty/bin/openresty -g 'daemon off;'
+          # 固定值，注意 dist 是构建生成的产物
+          copys:
+            - ${js-build}/dist:/usr/share/nginx/html/ # dist 是使用 npm run build 生成出来的目录，常见的目录有：public、dist 等
+            - ${js-build}/nginx.conf.template:/etc/nginx/conf.d/
+          image: registry.erda.cloud/erda/terminus-nginx:0.2
+```

--- a/actions/js-build/2.0/dice.yml
+++ b/actions/js-build/2.0/dice.yml
@@ -3,6 +3,7 @@ jobs:
   js-build:
     image: registry.erda.cloud/erda-actions/js-build-action:2.0-20230830111908-484b8b5
     envs:
+      node_version: "18"
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud
     resources:
       cpu: 1

--- a/actions/js-build/2.0/dice.yml
+++ b/actions/js-build/2.0/dice.yml
@@ -3,7 +3,7 @@ jobs:
   js-build:
     image: registry.erda.cloud/erda-actions/js-build-action:2.0-20230830111908-484b8b5
     envs:
-      node_version: "18"
+      ACTION_NODE_VERSION: "18"
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud
     resources:
       cpu: 1

--- a/actions/js-build/2.0/spec.yml
+++ b/actions/js-build/2.0/spec.yml
@@ -17,7 +17,7 @@ params:
   - name: node_version
     type: string
     desc: ${{ i18n.params.node_version.desc }}
-    default: "12"
+    default: "18"
   - name: workdir
     type: string
     desc: ${{ i18n.params.workdir.desc }}


### PR DESCRIPTION
## Description

Update default node version to v18 for js-build 2.0 Action

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [ ] My change is adequately tested.
