### PR TITLE
revert: spot-agent to 2.5.0 for service monitor

### DIFF
--- a/actions/buildpack/1.0/bp/node/pack/herd/Dockerfile
+++ b/actions/buildpack/1.0/bp/node/pack/herd/Dockerfile
@@ -11,7 +11,7 @@ RUN \
     bootjs=$(node -p "require('./package.json').scripts.start" | \
     sed -n -e 's/^.*herd //p') && \
     bootjs=${bootjs:-'Pampasfile-default.js'} && echo ${bootjs} && \
-    npm i @terminus/spot-agent@4.1.3 && \
+    npm i @terminus/spot-agent@~2.5.0 -g && \
     npm link @terminus/spot-agent && \
     spot install -r herd -s ${bootjs} || exit -1;
 

--- a/actions/buildpack/1.0/dice.yml
+++ b/actions/buildpack/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   buildpack:
-    image: registry.erda.cloud/erda-actions/buildpack-action:1.0-20230821114938-1ff4f6c1
+    image: registry.erda.cloud/erda-actions/buildpack-action:1.0-20230912165801-8ef9d0cb
     envs:
       # Dockerfile / Dockerfile.build 中 {{BP_DOCKER_BASE_REGISTRY}} 需要该环境变量进行文件渲染。
       # 作用：Dockerfile 里 FROM XXX，这个 XXX 镜像的 Registry 地址。


### PR DESCRIPTION
## Description

revert: spot-agent to 2.5.0 for service monitor

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [ ] My change is adequately tested.
