### PR TITLE
print git username for git-checkout

### DIFF
--- a/actions/git-checkout/1.0/dice.yml
+++ b/actions/git-checkout/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   git-checkout:
-    image: registry.erda.cloud/erda-actions/git-checkout-action:1.0-20230516131755-d565716
+    image: registry.erda.cloud/erda-actions/git-checkout-action:1.0-20240227100946-aed655a
     resources:
       cpu: 0.5
       mem: 1024

--- a/actions/git-checkout/1.0/internal/assets/internal_run.sh
+++ b/actions/git-checkout/1.0/internal/assets/internal_run.sh
@@ -79,6 +79,11 @@ if [ $isCommit = true ]; then
 else
     echo 'clone mode'
     pwd
+
+    gitusername=$(git config  user.name)
+    echo "git config user.name: $gitusername"
+    echo "git command:  git clone --single-branch $depthflag $uri $branchflag $destination"
+
     git clone --single-branch $depthflag $uri $branchflag $destination
     cd $destination
     git fetch origin refs/notes/*:refs/notes/*


### PR DESCRIPTION
## Description

Print git username for git-checkout, in case when git clone with the error "could not read Username for https://gittar.erda.cloud" happened for git-checkout, there is no information about  git username.

![image](https://github.com/erda-project/erda-actions/assets/22124772/7e1f5701-485b-4e19-b7a3-5bf1029f2107)



## Checklist

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
