### PR TITLE
feat: support running service as non-root for java,buildpack, js action

### DIFF
--- a/actions/buildpack-aliyun/1.0/dice.yml
+++ b/actions/buildpack-aliyun/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   buildpack-aliyun:
-    image: registry.erda.cloud/erda-actions/buildpack-aliyun-action:1.0-20230103141416-d085afc
+    image: registry.erda.cloud/erda-actions/buildpack-aliyun-action:1.0-20240314111031-384b1871
     envs:
       # Dockerfile / Dockerfile.build 中 {{BP_DOCKER_BASE_REGISTRY}} 需要该环境变量进行文件渲染。
       # 作用：Dockerfile 里 FROM XXX，这个 XXX 镜像的 Registry 地址。

--- a/actions/buildpack-aliyun/1.0/internal/run/conf/params.go
+++ b/actions/buildpack-aliyun/1.0/internal/run/conf/params.go
@@ -52,8 +52,9 @@ type params struct {
 	Modules    []*Module
 	ModulesStr string `env:"ACTION_MODULES" required:"true"`
 
-	HttpProxy  string `env:"ACTION_HTTP_PROXY" required:"false"`
-	HttpsProxy string `env:"ACTION_HTTPS_PROXY" required:"false"`
+	HttpProxy     string `env:"ACTION_HTTP_PROXY" required:"false"`
+	HttpsProxy    string `env:"ACTION_HTTPS_PROXY" required:"false"`
+	RunningAsRoot bool   `env:"ACTION_RUNNING_AS_ROOT" required:"false"`
 
 	// OnlyBuild means no pack step.
 	// +optional

--- a/actions/buildpack-aliyun/1.0/internal/run/pack/pack_buildkit.go
+++ b/actions/buildpack-aliyun/1.0/internal/run/pack/pack_buildkit.go
@@ -39,6 +39,7 @@ func PackForBuildkit() ([]byte, error) {
 
 /*
 context/
+
 	-- repo/
 	-- bp-backend/
 		-- bp/
@@ -89,6 +90,9 @@ func dockerPackBuildForBuildkit() ([]byte, error) {
 		return nil, err
 	}
 	newDockerfileContent := dockerfile.ReplaceOrInsertBuildArgToDockerfile(dockerfileContent, conf.Params().BpArgs)
+	if !conf.Params().RunningAsRoot {
+		newDockerfileContent = dockerfile.InsertErdaUserToDockerfile(newDockerfileContent)
+	}
 
 	//----------------------
 	newDockerfileContentLines := strings.Split(string(newDockerfileContent), "\n")

--- a/actions/buildpack/1.0/dice.yml
+++ b/actions/buildpack/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   buildpack:
-    image: registry.erda.cloud/erda-actions/buildpack-action:1.0-20230912165801-8ef9d0cb
+    image: registry.erda.cloud/erda-actions/buildpack-action:1.0-20240313161931-384b1871
     envs:
       # Dockerfile / Dockerfile.build 中 {{BP_DOCKER_BASE_REGISTRY}} 需要该环境变量进行文件渲染。
       # 作用：Dockerfile 里 FROM XXX，这个 XXX 镜像的 Registry 地址。

--- a/actions/buildpack/1.0/internal/run/conf/params.go
+++ b/actions/buildpack/1.0/internal/run/conf/params.go
@@ -52,8 +52,9 @@ type params struct {
 	Modules    []*Module
 	ModulesStr string `env:"ACTION_MODULES" required:"true"`
 
-	HttpProxy  string `env:"ACTION_HTTP_PROXY" required:"false"`
-	HttpsProxy string `env:"ACTION_HTTPS_PROXY" required:"false"`
+	HttpProxy     string `env:"ACTION_HTTP_PROXY" required:"false"`
+	HttpsProxy    string `env:"ACTION_HTTPS_PROXY" required:"false"`
+	RunningAsRoot bool   `env:"ACTION_RUNNING_AS_ROOT" required:"false"`
 
 	// OnlyBuild means no pack step.
 	// +optional

--- a/actions/buildpack/1.0/internal/run/pack/pack_buildkit.go
+++ b/actions/buildpack/1.0/internal/run/pack/pack_buildkit.go
@@ -91,6 +91,9 @@ func dockerPackBuildForBuildkit() ([]byte, error) {
 		return nil, err
 	}
 	newDockerfileContent := dockerfile.ReplaceOrInsertBuildArgToDockerfile(dockerfileContent, conf.Params().BpArgs)
+	if !conf.Params().RunningAsRoot {
+		newDockerfileContent = dockerfile.InsertErdaUserToDockerfile(newDockerfileContent)
+	}
 
 	//----------------------
 	newDockerfileContentLines := strings.Split(string(newDockerfileContent), "\n")

--- a/actions/java/1.0/dice.yml
+++ b/actions/java/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   java:
-    image: registry.erda.cloud/erda-actions/java-action:1.0-20230821111659-1ff4f6c1
+    image: registry.erda.cloud/erda-actions/java-action:1.0-20240314110058-384b1871
     envs:
       # 详见 actions/buildpack/1.0/dice.yml
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud

--- a/actions/java/1.0/internal/pkg/build/pack.go
+++ b/actions/java/1.0/internal/pkg/build/pack.go
@@ -3,6 +3,7 @@ package build
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/erda-project/erda-actions/pkg/dockerfile"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -149,6 +150,17 @@ func packAndPushAppImage(cfg conf.Conf) error {
 
 	if cfg.PreStartScript != "" {
 		buildArgs["SCRIPT_ARGS"] = cfg.PreStartArgs
+	}
+
+	if !cfg.RunningAsRoot {
+		dockerfileContent, err := os.ReadFile(dockerFilePath)
+		if err != nil {
+			return err
+		}
+		dockerfileContent = dockerfile.InsertErdaUserToDockerfile(dockerfileContent)
+		if err = filehelper.CreateFile(dockerFilePath, string(dockerfileContent), 0644); err != nil {
+			return err
+		}
 	}
 
 	// witch the build method

--- a/actions/java/1.0/internal/pkg/conf/conf.go
+++ b/actions/java/1.0/internal/pkg/conf/conf.go
@@ -23,6 +23,7 @@ type Conf struct {
 	MonitorAgent     string      `env:"ACTION_MONITOR" default:"true"`    // 是否使用监控 agent，若用户未配置，默认启用, true/false
 	PreStartScript   string      `env:"ACTION_PRE_START_SCRIPT"`          // 执行用户运行前脚本路径+名称，默认为项目根目录
 	PreStartArgs     string      `env:"ACTION_PRE_START_ARGS"`            // 执行用户运行前脚本参数
+	RunningAsRoot    bool        `env:"ACTION_RUNNING_AS_ROOT"`           // whether to run as root user
 	// pipeline注入，镜像生成需要
 	OrgID             int64  `env:"DICE_ORG_ID" required:"true"`
 	OrgName           string `env:"DICE_ORG_NAME" required:"true"`

--- a/actions/js/1.0/internal/pkg/conf/conf.go
+++ b/actions/js/1.0/internal/pkg/conf/conf.go
@@ -14,6 +14,7 @@ type Conf struct {
 	NpmUsername   string `env:"ACTION_NPM_USER"`
 	NpmPassword   string `env:"ACTION_NPM_PASSWORD"`
 	Service       string `env:"ACTION_SERVICE"` // 与 dice.yml 里 service 对应，部署时，通过 service 关联镜像 TODO deprecated
+	RunningAsRoot bool   `env:"ACTION_RUNNING_AS_ROOT" default:"false"`
 	// pipeline 注入，镜像生成时使用
 	TaskName       string `env:"PIPELINE_TASK_NAME" default:"unknown"`
 	ClusterName    string `env:"DICE_CLUSTER_NAME" required:"true"`

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -11,6 +11,30 @@ import (
 	"github.com/erda-project/erda/pkg/strutil"
 )
 
+var (
+	erdaUser = `RUN groupadd -g 1001 erda -f && useradd -u 1001 -g 1001 erda -o
+	USER erda
+	`
+)
+
+func InsertErdaUserToDockerfile(content []byte) []byte {
+	lines := strutil.Split(string(content), "\n", true)
+	var result []string
+	var hasInserted bool
+	for _, line := range lines {
+		if strings.HasPrefix(line, "ENTRYPOINT") || strings.HasPrefix(line, "CMD") {
+			result = append(result, erdaUser, line)
+			hasInserted = true
+			continue
+		}
+		result = append(result, line)
+	}
+	if !hasInserted {
+		result = append(result, erdaUser)
+	}
+	return []byte(strings.Join(result, "\n"))
+}
+
 func ReplaceOrInsertBuildArgToDockerfile(content []byte, buildArgs map[string]string) []byte {
 
 	// v 使用 json 序列化进行转义

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -101,3 +101,35 @@ ARG URL
 	}
 	fmt.Println(string(ReplaceOrInsertBuildArgToDockerfile(dockerfile, bpArgs)))
 }
+
+func TestInsertErdaUserToDockerfile(t *testing.T) {
+	dockerfile := []byte(`
+FROM registry.erda.cloud/retag/pyroscope-java:v0.11.5 as pyroscope-java
+FROM registry.erda.cloud/erda-x/openjdk:8_11
+
+ARG CONTAINER_VERSION=v8
+ENV CONTAINER_VERSION ${CONTAINER_VERSION}
+
+ENV SCRIPT_ARGS ${SCRIPT_ARGS}
+
+COPY comp/openjdk/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+COPY pre_start.sh /pre_start.sh
+RUN chmod +x /pre_start.sh
+
+COPY comp/fonts /usr/share/fonts/custom
+#COPY comp/arthas-boot.jar /
+COPY comp/jacocoagent.jar /opt/jacoco/jacocoagent.jar
+
+ARG ERDA_VERSION
+COPY comp/spot-agent/${ERDA_VERSION}/spot-agent.tar.gz /tmp/spot-agent.tar.gz
+RUN \
+	if [ "${MONITOR_AGENT}" = true ]; then \
+        mkdir -p /opt/spot; tar -xzf /tmp/spot-agent.tar.gz -C /opt/spot; \
+	fi && rm -rf /tmp/spot-agent.tar.gz
+
+ENTRYPOINT ["/entrypoint.sh"]
+`)
+	fmt.Println(string(InsertErdaUserToDockerfile(dockerfile)))
+}


### PR DESCRIPTION
## Description

support running service as non-root for java,buildpack, js action

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [ ] My change is adequately tested.
