### PR TITLE
feat: upgrade go version for custom-script v2

### DIFF
--- a/actions/custom-script/2.0/Dockerfile
+++ b/actions/custom-script/2.0/Dockerfile
@@ -31,6 +31,8 @@ RUN chown -R dice:dice /home/dice/.m2 \
   && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2 \
   && npm install -g yarn
 
+RUN git clone https://github.com/udhos/update-golang && cd update-golang && RELEASE=1.22.5 ./update-golang.sh && source /etc/profile.d/golang_path.sh
+
 ARG TARGETARCH
 RUN yum erase -y git && cd /opt && curl -O -L https://erda-project.oss-cn-hangzhou.aliyuncs.com/erda-addons/git-$TARGETARCH.tgz && tar -xzvf git-$TARGETARCH.tgz && rm -fv git-$TARGETARCH.tgz
 ENV PATH=/opt/git/bin:$PATH

--- a/actions/custom-script/2.0/dice.yml
+++ b/actions/custom-script/2.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   custom-script:
-    image: registry.erda.cloud/erda-actions/custom-script-action:2.0-20230608153022-685950d
+    image: registry.erda.cloud/erda-actions/custom-script-action:2.0-20240708110557-33240a5b
     resources:
       cpu: 0.1
       mem: 1024


### PR DESCRIPTION
## Description
go v1.22.5

upgrade go version for custom-script v2

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
