### PR TITLE
fix(java): improve memory management and update base images

### DIFF
--- a/actions/java/1.0/Dockerfile
+++ b/actions/java/1.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM registry.erda.cloud/erda-x/golang:1.22 AS builder
+FROM registry.erda.cloud/erda-x/golang:1.22 AS builder
 
 COPY . /go/src/github.com/erda-project/erda-actions
 WORKDIR /go/src/github.com/erda-project/erda-actions
@@ -15,8 +15,9 @@ RUN mkdir -p /opt/action/comp && \
 RUN bash /opt/action/comp/download_spot_agent.sh
 RUN bash /opt/action/comp/download_fonts.sh
 
-FROM --platform=$TARGETPLATFORM registry.erda.cloud/retag/buildkit:v0.11.6 AS buildkit
-FROM --platform=$TARGETPLATFORM registry.erda.cloud/erda-x/openjdk:8_11_17_21
+FROM registry.erda.cloud/retag/buildkit:v0.11.6 AS buildkit
+FROM registry.erda.cloud/retag/docker:28.2.2-cli AS docker-cli
+FROM registry.erda.cloud/erda-x/openjdk:8_11_17_21_oraclelinux9
 
 ENV HOME=/root
 
@@ -32,10 +33,7 @@ RUN gawk -i inplace '/<mirror>/ { in_block=1; buffer=$0; is_target_block=0; next
 
 # install docker-cli & buildctl
 COPY --from=buildkit /usr/bin/buildctl /usr/bin/buildctl
-RUN dnf install -y dnf-plugins-core \
-    && dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
-    && dnf install -y docker-ce-cli \
-    && dnf clean all
+COPY --from=docker-cli /usr/local/bin/docker /usr/bin/docker
 
 COPY --from=builder /opt/action/run /opt/action/run
 COPY --from=builder /opt/action/comp /opt/action/comp

--- a/actions/java/1.0/Dockerfile
+++ b/actions/java/1.0/Dockerfile
@@ -26,7 +26,7 @@ SHELL ["/bin/bash", "-lc"]
 # install maven by sdkman
 RUN dnf install -y zip && dnf clean all
 RUN curl -s "https://get.sdkman.io" | bash
-RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk install maven 3.9.9
+RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk install maven 3.9.10
 ENV PATH="$HOME/.sdkman/candidates/maven/current/bin:$PATH"
 RUN gawk -i inplace '/<mirror>/ { in_block=1; buffer=$0; is_target_block=0; next } in_block { buffer = buffer "\n" $0; if ($0 ~ /<id>maven-default-http-blocker<\/id>/) is_target_block=1; if ($0 ~ /<\/mirror>/) { if (is_target_block) print "<!--\n" buffer "\n-->"; else print buffer; in_block=0; } next } !in_block { print }' /root/.sdkman/candidates/maven/current/conf/settings.xml
 

--- a/actions/java/1.0/comp/openjdk/Dockerfile
+++ b/actions/java/1.0/comp/openjdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.erda.cloud/retag/pyroscope-java:v0.11.5 as pyroscope-java
+FROM registry.erda.cloud/retag/pyroscope-java:v0.11.5 AS pyroscope-java
 FROM registry.erda.cloud/erda-x/openjdk:8_11_17_21
 
 ARG CONTAINER_VERSION=8

--- a/actions/java/1.0/comp/openjdk/Dockerfile
+++ b/actions/java/1.0/comp/openjdk/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.erda.cloud/retag/pyroscope-java:v0.11.5 AS pyroscope-java
-FROM registry.erda.cloud/erda-x/openjdk:8_11_17_21
+FROM registry.erda.cloud/erda-x/openjdk:8_11_17_21_oraclelinux9
 
 ARG CONTAINER_VERSION=8
 ENV CONTAINER_VERSION ${CONTAINER_VERSION}

--- a/actions/java/1.0/comp/openjdk/entrypoint.sh
+++ b/actions/java/1.0/comp/openjdk/entrypoint.sh
@@ -29,7 +29,34 @@ if [ -n "$VERSION_NUM" ] && [ "$VERSION_NUM" != "8" ]; then
     fi
 fi
 
-limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+# Initialize memory_unlimited flag
+memory_unlimited=0
+
+if [[ -f /sys/fs/cgroup/cgroup.controllers ]]; then
+  # cgroup v2
+  echo "Using cgroup v2"
+  memory=$(cat /sys/fs/cgroup/memory.max 2>/dev/null)
+  if [ "$memory" != "max" ]; then
+    limit_in_bytes=$memory
+  else
+    memory_unlimited=1
+  fi
+else
+  echo "Using cgroup v1"
+  # default cgroup v1
+  memory=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null)
+  if [ "$memory" != "9223372036854771712" ]; then
+     limit_in_bytes=$memory
+  else
+    memory_unlimited=1
+  fi
+fi
+
+if [ "$memory_unlimited" -eq 1 ]; then
+  echo "Memory is unlimited."
+else
+  echo "Memory limited in bytes: $limit_in_bytes"
+fi
 
 version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
 echo version "$version"
@@ -39,7 +66,7 @@ echo major "$major"
 export USER_JAVA_OPTS="$JAVA_OPTS"
 
 # If not default limit_in_bytes in cgroup
-if [ "$limit_in_bytes" -ne "9223372036854771712" ] && [ -z "${JAVA_OPTS_DISABLE_PRESET:-}" ]
+if [ "${memory_unlimited}" -ne 1 ] && [ -z "${JAVA_OPTS_DISABLE_PRESET:-}" ]
 then
     limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
 
@@ -74,7 +101,8 @@ then
 
     if (( major < 11 )); then
       export JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom $JAVA_OPTS"
-      export JAVA_OPTS="-XX:+UseContainerSupport -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:NewRatio=1 -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 $JAVA_OPTS"
+      # UseContainerSupport: default is true after version JDK8u191
+      export JAVA_OPTS="-XX:NewRatio=1 -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 $JAVA_OPTS"
     fi
 fi
 

--- a/actions/java/1.0/comp/tomcat/entrypoint.sh
+++ b/actions/java/1.0/comp/tomcat/entrypoint.sh
@@ -1,5 +1,33 @@
 #!/bin/bash
-limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+
+# Initialize memory_unlimited flag
+memory_unlimited=0
+
+if [[ -f /sys/fs/cgroup/cgroup.controllers ]]; then
+  # cgroup v2
+  echo "Using cgroup v2"
+  memory=$(cat /sys/fs/cgroup/memory.max 2>/dev/null)
+  if [ "$memory" != "max" ]; then
+    limit_in_bytes=$memory
+  else
+    memory_unlimited=1
+  fi
+else
+  echo "Using cgroup v1"
+  # default cgroup v1
+  memory=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null)
+  if [ "$memory" != "9223372036854771712" ]; then
+     limit_in_bytes=$memory
+  else
+    memory_unlimited=1
+  fi
+fi
+
+if [ "$memory_unlimited" -eq 1 ]; then
+  echo "Memory is unlimited."
+else
+  echo "Memory limited in bytes: $limit_in_bytes"
+fi
 
 export USER_JAVA_OPTS="$JAVA_OPTS"
 
@@ -20,7 +48,7 @@ if [ "$VERSION_NUM" != "8" ]; then
 fi
 
 # If not default limit_in_bytes in cgroup
-if [ "$limit_in_bytes" -ne "9223372036854771712" ]
+if [ "${memory_unlimited}" -ne 1 ]
 then
     limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
 
@@ -56,11 +84,7 @@ then
         fi
     fi
 
-    export JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+PrintGCDetails -XX:+PrintGCTimeStamps $JAVA_OPTS"
-    if [[ "$CONTAINER_VERSION" != v8* ]]; then
-        export JAVA_OPTS="-XX:+UseContainerSupport $JAVA_OPTS"
-    fi
-    echo JAVA_OPTS=$JAVA_OPTS
+    export JAVA_OPTS="-XX:+PrintGCDetails -XX:+PrintGCTimeStamps $JAVA_OPTS"
 fi
 
 # if user add DISABLE_PRESET_JAVA_OPTS env clear erda JAVA_OPTS

--- a/actions/java/1.0/dice.yml
+++ b/actions/java/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   java:
-    image: registry.erda.cloud/erda-actions/java-action:1.0-20250519171316-46f89dd
+    image: registry.erda.cloud/erda-actions/java-action:1.0-20250620161149-0c6f5ef4
     envs:
       # 详见 actions/buildpack/1.0/dice.yml
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud

--- a/actions/java/1.0/dice.yml
+++ b/actions/java/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   java:
-    image: registry.erda.cloud/erda-actions/java-action:1.0-20250701090817-a413d471
+    image: registry.erda.cloud/erda-actions/java-action:1.0-20250701090818-a413d471
     envs:
       # 详见 actions/buildpack/1.0/dice.yml
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud

--- a/actions/java/1.0/dice.yml
+++ b/actions/java/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   java:
-    image: registry.erda.cloud/erda-actions/java-action:1.0-20250620161149-0c6f5ef4
+    image: registry.erda.cloud/erda-actions/java-action:1.0-20250701090817-a413d471
     envs:
       # 详见 actions/buildpack/1.0/dice.yml
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud


### PR DESCRIPTION
## Description
-  Refactor cgroup memory limit detection for better compatibility
- Update Maven version from 3.9.9 to 3.9.10
- Remove redundant UseContainerSupport flag for JDK 8u191+
- Update OpenJDK base image to version with Oracle Linux9

[erda issue](https://erda.cloud/erda/dop/projects/387/issues/all?id=765805&iterationID=12783&type=TASK)

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
