### PR TITLE
build(java): upgrade jdk base image to ubuntu24.04

### DIFF
--- a/actions/java/1.0/Dockerfile
+++ b/actions/java/1.0/Dockerfile
@@ -17,19 +17,39 @@ RUN bash /opt/action/comp/download_fonts.sh
 
 FROM registry.erda.cloud/retag/buildkit:v0.11.6 AS buildkit
 FROM registry.erda.cloud/retag/docker:28.2.2-cli AS docker-cli
-FROM registry.erda.cloud/erda-x/openjdk:8_11_17_21
+FROM registry.erda.cloud/erda-x/openjdk:8_11_17_21-ubuntu24.04
 
 ENV HOME=/root
 
 # 设置默认使用 bash 作为 shell
 SHELL ["/bin/bash", "-lc"]
 
-# install maven by sdkman
-RUN dnf install -y zip && dnf clean all
-RUN curl -s "https://get.sdkman.io" | bash
-RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk install maven 3.9.10
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gawk \
+        zip \
+        unzip \
+        curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN curl -s "https://get.sdkman.io" | bash && \
+    source "$HOME/.sdkman/bin/sdkman-init.sh" && \
+    sdk install maven 3.9.10 && \
+    gawk -i inplace '/<mirror>/ { in_block=1; buffer=$0; is_target_block=0; next } \
+        in_block { buffer = buffer "\n" $0; \
+            if ($0 ~ /<id>maven-default-http-blocker<\/id>/) is_target_block=1; \
+            if ($0 ~ /<\/mirror>/) { \
+                if (is_target_block) print "<!--\n" buffer "\n-->"; \
+                else print buffer; \
+                in_block=0; \
+            } \
+            next \
+        } \
+        !in_block { print }' \
+        /root/.sdkman/candidates/maven/current/conf/settings.xml
+
 ENV PATH="$HOME/.sdkman/candidates/maven/current/bin:$PATH"
-RUN gawk -i inplace '/<mirror>/ { in_block=1; buffer=$0; is_target_block=0; next } in_block { buffer = buffer "\n" $0; if ($0 ~ /<id>maven-default-http-blocker<\/id>/) is_target_block=1; if ($0 ~ /<\/mirror>/) { if (is_target_block) print "<!--\n" buffer "\n-->"; else print buffer; in_block=0; } next } !in_block { print }' /root/.sdkman/candidates/maven/current/conf/settings.xml
 
 # install docker-cli & buildctl
 COPY --from=buildkit /usr/bin/buildctl /usr/bin/buildctl

--- a/actions/java/1.0/Dockerfile
+++ b/actions/java/1.0/Dockerfile
@@ -17,7 +17,7 @@ RUN bash /opt/action/comp/download_fonts.sh
 
 FROM registry.erda.cloud/retag/buildkit:v0.11.6 AS buildkit
 FROM registry.erda.cloud/retag/docker:28.2.2-cli AS docker-cli
-FROM registry.erda.cloud/erda-x/openjdk:8_11_17_21_oraclelinux9
+FROM registry.erda.cloud/erda-x/openjdk:8_11_17_21
 
 ENV HOME=/root
 

--- a/actions/java/1.0/comp/openjdk/Dockerfile
+++ b/actions/java/1.0/comp/openjdk/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.erda.cloud/retag/pyroscope-java:v0.11.5 AS pyroscope-java
-FROM registry.erda.cloud/erda-x/openjdk:8_11_17_21
+FROM registry.erda.cloud/erda-x/openjdk:8_11_17_21-ubuntu24.04
 
 ARG CONTAINER_VERSION=8
 ENV CONTAINER_VERSION ${CONTAINER_VERSION}

--- a/actions/java/1.0/comp/openjdk/Dockerfile
+++ b/actions/java/1.0/comp/openjdk/Dockerfile
@@ -24,7 +24,7 @@ ARG ERDA_VERSION
 COPY comp/spot-agent/${ERDA_VERSION}/spot-agent.tar.gz /tmp/spot-agent.tar.gz
 RUN \
 	if [ "${MONITOR_AGENT}" = true ]; then \
-        mkdir -p /opt/spot; tar -xzf /tmp/spot-agent.tar.gz -C /opt/spot; \
+        mkdir -p /opt/spot; tar --no-same-owner --no-same-permissions -xzf /tmp/spot-agent.tar.gz -C /opt/spot; \
 	fi && rm -rf /tmp/spot-agent.tar.gz
 
 COPY --from=pyroscope-java /app /opt/pyroscope

--- a/actions/java/1.0/comp/openjdk/Dockerfile
+++ b/actions/java/1.0/comp/openjdk/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.erda.cloud/retag/pyroscope-java:v0.11.5 AS pyroscope-java
-FROM registry.erda.cloud/erda-x/openjdk:8_11_17_21_oraclelinux9
+FROM registry.erda.cloud/erda-x/openjdk:8_11_17_21
 
 ARG CONTAINER_VERSION=8
 ENV CONTAINER_VERSION ${CONTAINER_VERSION}

--- a/actions/java/1.0/comp/openjdk/entrypoint.sh
+++ b/actions/java/1.0/comp/openjdk/entrypoint.sh
@@ -19,12 +19,26 @@ if [ -n "$VERSION_NUM" ] && [ "$VERSION_NUM" != "8" ]; then
     JAVA_PATH=$(update-alternatives --list java | grep "java-$VERSION_NUM" | head -n 1)
     if echo "$JAVA_PATH" | grep -q "/jre/bin/java"; then
       JAVAC_PATH=$(echo "$JAVA_PATH" | sed 's#/jre/bin/java#/bin/javac#');
+      JPS_PATH=$(echo "$JAVA_PATH" | sed 's#/jre/bin/java#/bin/jps#')
     else
       JAVAC_PATH=$(echo "$JAVA_PATH" | sed 's#/bin/java#/bin/javac#');
+      JPS_PATH=$(echo "$JAVA_PATH" | sed 's#/bin/java#/bin/jps#')
     fi
     update-alternatives --set java "$JAVA_PATH"
     update-alternatives --set javac "$JAVAC_PATH"
+    if [ -x "$JPS_PATH" ]; then
+      update-alternatives --set jps "$JPS_PATH"
+    else
+      echo "WARN: jps not found at $JPS_PATH, skipping update-alternatives --set jps"
+    fi
 fi
+
+# setting java home
+JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 \
+  | grep 'java.home' | awk -F= '{print $2}' | tr -d ' ')
+export JAVA_HOME
+echo "JAVA_HOME: $JAVA_HOME"
+echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc
 
 # Initialize memory_unlimited flag
 memory_unlimited=0

--- a/actions/java/1.0/comp/openjdk/entrypoint.sh
+++ b/actions/java/1.0/comp/openjdk/entrypoint.sh
@@ -16,17 +16,14 @@ echo "VERSION_NUM: $VERSION_NUM"
 
 # only reset if version is not 8
 if [ -n "$VERSION_NUM" ] && [ "$VERSION_NUM" != "8" ]; then
-    alternatives --set java "$(alternatives --list | grep "java_sdk_${VERSION_NUM}"  | awk '{print $3}' | head -n 1)/bin/java"
-    alternatives --set javac "$(alternatives --list | grep "java_sdk_${VERSION_NUM}"  | awk '{print $3}' | head -n 1)/bin/javac"
-    export JAVA_HOME=/usr/lib/jvm/java-${VERSION_NUM}
-    # Ensure JAVA_HOME is valid before writing to bashrc
-    if [ -d "${JAVA_HOME}" ]; then
-        echo "export JAVA_HOME=${JAVA_HOME}" >> /root/.bashrc
-        echo "export JAVA_HOME=${JAVA_HOME}" >> /home/dice/.bashrc
+    JAVA_PATH=$(update-alternatives --list java | grep "java-$VERSION_NUM" | head -n 1)
+    if echo "$JAVA_PATH" | grep -q "/jre/bin/java"; then
+      JAVAC_PATH=$(echo "$JAVA_PATH" | sed 's#/jre/bin/java#/bin/javac#');
     else
-        echo "Warning: JAVA_HOME=${JAVA_HOME} is not a valid directory. Not adding to .bashrc files."
-        exit 1
+      JAVAC_PATH=$(echo "$JAVA_PATH" | sed 's#/bin/java#/bin/javac#');
     fi
+    update-alternatives --set java "$JAVA_PATH"
+    update-alternatives --set javac "$JAVAC_PATH"
 fi
 
 # Initialize memory_unlimited flag

--- a/actions/java/1.0/dice.yml
+++ b/actions/java/1.0/dice.yml
@@ -1,10 +1,7 @@
 ### job 配置项
 jobs:
   java:
-    image: registry.erda.cloud/erda-actions/java-action:1.0-20250702100322-97262b3b
-    # Solve the Hygon cpu crash problem:
-    # https://github.com/ceph/ceph-csi/issues/4379#issuecomment-2586482607
-    # image: registry.erda.cloud/erda-actions/java-action:1.0-20250701090818-a413d471
+    image: registry.erda.cloud/erda-actions/java-action:1.0-20250703153146-3bd44a93
     envs:
       # 详见 actions/buildpack/1.0/dice.yml
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud

--- a/actions/java/1.0/dice.yml
+++ b/actions/java/1.0/dice.yml
@@ -1,7 +1,10 @@
 ### job 配置项
 jobs:
   java:
-    image: registry.erda.cloud/erda-actions/java-action:1.0-20250701090818-a413d471
+    image: registry.erda.cloud/erda-actions/java-action:1.0-20250702100322-97262b3b
+    # Solve the Hygon cpu crash problem:
+    # https://github.com/ceph/ceph-csi/issues/4379#issuecomment-2586482607
+    # image: registry.erda.cloud/erda-actions/java-action:1.0-20250701090818-a413d471
     envs:
       # 详见 actions/buildpack/1.0/dice.yml
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud

--- a/actions/java/1.0/dice.yml
+++ b/actions/java/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   java:
-    image: registry.erda.cloud/erda-actions/java-action:1.0-20250703153146-3bd44a93
+    image: registry.erda.cloud/erda-actions/java-action:1.0-20250703174411-048da034
     envs:
       # 详见 actions/buildpack/1.0/dice.yml
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud

--- a/actions/java/1.0/dice.yml
+++ b/actions/java/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   java:
-    image: registry.erda.cloud/erda-actions/java-action:1.0-20250710174424-aafffa93
+    image: registry.erda.cloud/erda-actions/java-action:1.0-20250711154256-ed0a480a
     envs:
       # 详见 actions/buildpack/1.0/dice.yml
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud

--- a/actions/java/1.0/dice.yml
+++ b/actions/java/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   java:
-    image: registry.erda.cloud/erda-actions/java-action:1.0-20250703174411-048da034
+    image: registry.erda.cloud/erda-actions/java-action:1.0-20250710174424-aafffa93
     envs:
       # 详见 actions/buildpack/1.0/dice.yml
       BP_DOCKER_BASE_REGISTRY: registry.erda.cloud

--- a/pkg/jdk/switcher.go
+++ b/pkg/jdk/switcher.go
@@ -1,0 +1,16 @@
+package jdk
+
+// VersionSwitcher Java version switcher interface
+type VersionSwitcher interface {
+	// SwitchToVersion switches to the specified Java version
+	SwitchToVersion(version string) error
+
+	// GetCurrentJavaHome gets the JAVA_HOME of the current Java version
+	GetCurrentJavaHome() (string, error)
+
+	// IsVersionSupported checks if the specified version is supported
+	IsVersionSupported(version string) bool
+
+	// ListAvailableVersions lists all available Java versions
+	ListAvailableVersions() ([]string, error)
+}

--- a/pkg/jdk/update_alternatives.go
+++ b/pkg/jdk/update_alternatives.go
@@ -1,0 +1,150 @@
+package jdk
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var defaultSupportedVersions = map[string]bool{
+	"8":  true,
+	"11": true,
+	"17": true,
+	"21": true,
+}
+
+// UpdateAlternativesSwitcher update-alternatives Java version switcher implementation
+type UpdateAlternativesSwitcher struct {
+	supportedVersions map[string]bool
+}
+
+func NewUpdateAlternativesSwitcher() *UpdateAlternativesSwitcher {
+	return &UpdateAlternativesSwitcher{
+		supportedVersions: defaultSupportedVersions,
+	}
+}
+
+// SwitchToVersion switches to the specified Java version
+func (s *UpdateAlternativesSwitcher) SwitchToVersion(version string) error {
+	if !s.IsVersionSupported(version) {
+		return fmt.Errorf("unsupported Java version: %s", version)
+	}
+
+	fmt.Printf("Switching to Java %s...\n", version)
+
+	// 1. Find available Java version
+	javaPath, err := s.findJavaPath(version)
+	if err != nil {
+		return fmt.Errorf("java %s version not found: %v", version, err)
+	}
+
+	fmt.Printf("Found Java %s path: %s\n", version, javaPath)
+
+	// 2. Set java
+	if err := s.runCommand(fmt.Sprintf("update-alternatives --set java \"%s\"", javaPath)); err != nil {
+		return fmt.Errorf("failed to set java: %v", err)
+	}
+
+	// 3. Intelligently derive and set javac path
+	javacPath := s.deriveJavacPath(javaPath)
+	if err := s.runCommand(fmt.Sprintf("update-alternatives --set javac \"%s\"", javacPath)); err != nil {
+		return fmt.Errorf("failed to set javac: %v", err)
+	}
+
+	fmt.Printf("Successfully switched to Java %s\n", version)
+	return nil
+}
+
+// GetCurrentJavaHome gets the JAVA_HOME of the current Java version
+func (s *UpdateAlternativesSwitcher) GetCurrentJavaHome() (string, error) {
+	cmd := exec.Command("/bin/bash", "-c", "java -XshowSettings:properties -version 2>&1 | grep 'java.home' | awk -F= '{print $2}' | tr -d ' '")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get JAVA_HOME: %v", err)
+	}
+
+	javaHome := strings.TrimSpace(string(output))
+	if javaHome == "" {
+		return "", errors.New("java.home is empty")
+	}
+
+	return javaHome, nil
+}
+
+// IsVersionSupported checks if the specified version is supported
+func (s *UpdateAlternativesSwitcher) IsVersionSupported(version string) bool {
+	return s.supportedVersions[version]
+}
+
+// ListAvailableVersions lists all available Java versions
+func (s *UpdateAlternativesSwitcher) ListAvailableVersions() ([]string, error) {
+	cmd := exec.Command("/bin/bash", "-c", "update-alternatives --list java")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Java version list: %v", err)
+	}
+
+	lines := strings.Split(string(output), "\n")
+	var versions []string
+	versionSet := make(map[string]bool)
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Extract version number from path, e.g.: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -> 8
+		for version := range s.supportedVersions {
+			if strings.Contains(line, fmt.Sprintf("java-%s", version)) && !versionSet[version] {
+				versions = append(versions, version)
+				versionSet[version] = true
+				break
+			}
+		}
+	}
+
+	return versions, nil
+}
+
+// findJavaPath finds the Java path for the specified version
+func (s *UpdateAlternativesSwitcher) findJavaPath(version string) (string, error) {
+	cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf("update-alternatives --list java | grep 'java-%s' | head -n 1", version))
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	javaPath := strings.TrimSpace(string(output))
+	if javaPath == "" {
+		return "", fmt.Errorf("java %s path is empty", version)
+	}
+
+	return javaPath, nil
+}
+
+// DeriveJavacPath derives javac path from java path (exported for testing)
+func (s *UpdateAlternativesSwitcher) DeriveJavacPath(javaPath string) string {
+	return s.deriveJavacPath(javaPath)
+}
+
+// deriveJavacPath derives javac path from java path
+func (s *UpdateAlternativesSwitcher) deriveJavacPath(javaPath string) string {
+	if strings.Contains(javaPath, "/jre/bin/java") {
+		// JRE path: /usr/lib/jvm/java-8-xxx/jre/bin/java -> /usr/lib/jvm/java-8-xxx/bin/javac
+		return strings.Replace(javaPath, "/jre/bin/java", "/bin/javac", 1)
+	} else {
+		// JDK path: /usr/lib/jvm/java-11-xxx/bin/java -> /usr/lib/jvm/java-11-xxx/bin/javac
+		return strings.Replace(javaPath, "/bin/java", "/bin/javac", 1)
+	}
+}
+
+// runCommand executes command
+func (s *UpdateAlternativesSwitcher) runCommand(cmd string) error {
+	command := exec.Command("/bin/bash", "-c", cmd)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
+}

--- a/pkg/jdk/update_alternatives_test.go
+++ b/pkg/jdk/update_alternatives_test.go
@@ -1,0 +1,77 @@
+package jdk
+
+import (
+	"testing"
+)
+
+func TestUpdateAlternativesSwitcher_IsVersionSupported(t *testing.T) {
+	switcher := NewUpdateAlternativesSwitcher()
+
+	tests := []struct {
+		version  string
+		expected bool
+	}{
+		{"8", true},
+		{"11", true},
+		{"17", true},
+		{"21", true},
+		{"7", false},
+		{"12", false},
+		{"", false},
+	}
+
+	for _, test := range tests {
+		result := switcher.IsVersionSupported(test.version)
+		if result != test.expected {
+			t.Errorf("IsVersionSupported(%s) = %v; expected %v", test.version, result, test.expected)
+		}
+	}
+}
+
+func TestUpdateAlternativesSwitcher_DeriveJavacPath(t *testing.T) {
+	switcher := NewUpdateAlternativesSwitcher()
+
+	tests := []struct {
+		javaPath     string
+		expectedPath string
+	}{
+		{
+			"/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
+			"/usr/lib/jvm/java-8-openjdk-amd64/bin/javac",
+		},
+		{
+			"/usr/lib/jvm/java-11-openjdk-amd64/bin/java",
+			"/usr/lib/jvm/java-11-openjdk-amd64/bin/javac",
+		},
+		{
+			"/usr/lib/jvm/java-17-openjdk-arm64/bin/java",
+			"/usr/lib/jvm/java-17-openjdk-arm64/bin/javac",
+		},
+	}
+
+	for _, test := range tests {
+		result := switcher.DeriveJavacPath(test.javaPath)
+		if result != test.expectedPath {
+			t.Errorf("DeriveJavacPath(%s) = %s; expected %s", test.javaPath, result, test.expectedPath)
+		}
+	}
+}
+
+func TestNewUpdateAlternativesSwitcher(t *testing.T) {
+	switcher := NewUpdateAlternativesSwitcher()
+
+	if switcher == nil {
+		t.Error("NewUpdateAlternativesSwitcher() returned nil")
+	}
+
+	if switcher.supportedVersions == nil {
+		t.Error("supportedVersions map is nil")
+	}
+
+	expectedVersions := []string{"8", "11", "17", "21"}
+	for _, version := range expectedVersions {
+		if !switcher.IsVersionSupported(version) {
+			t.Errorf("Expected version %s to be supported", version)
+		}
+	}
+}


### PR DESCRIPTION
## Description

- Replace hardcoded JDK switch commands with a more flexible implementation
- Use update-alternatives to manage Java versions
- Add support for detecting and switching between multiple Java versions
- Improve error handling and logging- Update Dockerfile to use Ubuntu24.04 base image

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
