### PR TITLE
chore: Update nginx registry address

### DIFF
--- a/actions/js-build/1.0/README.md
+++ b/actions/js-build/1.0/README.md
@@ -65,5 +65,5 @@ spa 模式
           copys:
             - ${js-build}/dist:/usr/share/nginx/html/   # dist 是使用 npm run build 生成出来的目录，常见的目录有：public、dist 等
             - ${js-build}/nginx.conf.template:/etc/nginx/conf.d/
-          image: registry.erda.cloud/erda/terminus-nginx:0.2
+          image: registry.erda.cloud/erda/nginx:1.27.1.2
 ```

--- a/actions/js-build/2.0/README.md
+++ b/actions/js-build/2.0/README.md
@@ -64,6 +64,6 @@ spa 模式
           copys:
             - ${js-build}/dist:/usr/share/nginx/html/ # dist 是使用 npm run build 生成出来的目录，常见的目录有：public、dist 等
             - ${js-build}/nginx.conf.template:/etc/nginx/conf.d/
-          image: registry.erda.cloud/erda/terminus-nginx:0.2
+          image: registry.erda.cloud/erda/nginx:1.27.1.2
 ```
 

--- a/actions/virtual-offline-image/1.0/dice.yml
+++ b/actions/virtual-offline-image/1.0/dice.yml
@@ -45,7 +45,7 @@ jobs:
   js-herd:
     image: registry.erda.cloud/erda-actions/terminus-herd:1.1.8-node12
   js-spa:
-    image: registry.erda.cloud/erda-actions/terminus-nginx:0.2
+    image: registry.erda.cloud/erda/nginx:1.27.1.2
 
   ### spa
   dice-nginx-1-1-0:

--- a/dockerfiles/terminus-nginx/openresty.1.27.1/Dockerfile
+++ b/dockerfiles/terminus-nginx/openresty.1.27.1/Dockerfile
@@ -36,7 +36,7 @@ ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
-       dnsutils tcpdump lsof net-tools telnet nmap ncat \
+       dnsutils tcpdump lsof net-tools telnet ncat \
        vim bat ripgrep \
        wget aria2 unzip \
     && ln -s /usr/bin/batcat /usr/local/bin/bat \

--- a/dockerfiles/terminus-nginx/openresty.1.27.1/deploy.sh
+++ b/dockerfiles/terminus-nginx/openresty.1.27.1/deploy.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-image=registry.erda.cloud/erda-actions/nginx:1.27.1
+image=registry.erda.cloud/erda/nginx:1.27.1.2
 
 docker buildx build --platform linux/amd64,linux/arm64 -t ${image} --push . -f Dockerfile
 
-echo "action meta: nginx-1.27.1=$image"
+echo "action meta: nginx-1.27.1.2=$image"


### PR DESCRIPTION
## Description

chore: Update nginx registry address
需要重新推下 `registry.erda.cloud/erda/nginx:1.27.1` 这个镜像，感觉比之前的 `erda-actions` 更合理一些

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
