### PR TITLE
feat: add support for spot-agent version 2.4

### DIFF
--- a/actions/buildpack/1.0/sync_assets.sh
+++ b/actions/buildpack/1.0/sync_assets.sh
@@ -56,8 +56,8 @@ for i in {1..6}; do
     download ${release_1_first_version} ${i} ${assetsDir}
 done
 
-## release erda 1.x
-release_2_first_version=2
-for i in {0..0}; do
-    download ${release_2_first_version} ${i} ${assetsDir}
-done
+## release erda 2.x
+# 只下载 2.0 和 2.4
+
+download 2 0 ${assetsDir}
+download 2 4 ${assetsDir}

--- a/pkg/version/version_util.go
+++ b/pkg/version/version_util.go
@@ -15,6 +15,7 @@ var agentHistoryVersions = []string{
 	"1.5",
 	"1.6",
 	"2.0",
+	"2.4",
 }
 
 func IsHistoryVersion(version string) bool {


### PR DESCRIPTION


## Description

- Add version 2.4 to agentHistoryVersions in version_util.go
- Update sync_assets.sh to download both erda 2.0 and 2.4 spot-agent

