### PR TITLE
build: update docker version and golang version

### DIFF
--- a/actions/buildpack-aliyun/1.0/Dockerfile
+++ b/actions/buildpack-aliyun/1.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.erda.cloud/retag/buildkit:v0.11.3 AS buildkit
-FROM registry.erda.cloud/retag/docker:28.2.2-cli AS docker-cli
+FROM registry.erda.cloud/retag/docker:20.10.24-cli AS docker-cli
 FROM registry.erda.cloud/erda-x/golang:1.22 AS builder
 
 COPY . /go/src/github.com/erda-project/erda-actions

--- a/actions/buildpack/1.0/Dockerfile
+++ b/actions/buildpack/1.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.erda.cloud/retag/buildkit:v0.11.3 AS buildkit
-FROM registry.erda.cloud/retag/docker:28.2.2-cli AS docker-cli
-FROM registry.erda.cloud/erda-x/golang:1.22 AS builder
+FROM registry.erda.cloud/retag/docker:20.10.24-cli AS docker-cli
+FROM registry.erda.cloud/erda-x/golang:1.24 AS builder
 
 COPY . /go/src/github.com/erda-project/erda-actions
 WORKDIR /go/src/github.com/erda-project/erda-actions

--- a/actions/buildpack/1.0/dice.yml
+++ b/actions/buildpack/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   buildpack:
-    image: registry.erda.cloud/erda-actions/buildpack-action:1.0-20250710133435-1b83a65d
+    image: registry.erda.cloud/erda-actions/buildpack-action:1.0-20250827143004-73995e35
     envs:
       # Dockerfile / Dockerfile.build 中 {{BP_DOCKER_BASE_REGISTRY}} 需要该环境变量进行文件渲染。
       # 作用：Dockerfile 里 FROM XXX，这个 XXX 镜像的 Registry 地址。

--- a/actions/java/1.0/Dockerfile
+++ b/actions/java/1.0/Dockerfile
@@ -16,7 +16,7 @@ RUN bash /opt/action/comp/download_spot_agent.sh
 RUN bash /opt/action/comp/download_fonts.sh
 
 FROM registry.erda.cloud/retag/buildkit:v0.11.6 AS buildkit
-FROM registry.erda.cloud/retag/docker:28.2.2-cli AS docker-cli
+FROM registry.erda.cloud/retag/docker:20.10.24-cli AS docker-cli
 FROM registry.erda.cloud/erda-x/openjdk:8_11_17_21-ubuntu24.04
 
 ENV HOME=/root


### PR DESCRIPTION
## Description

Will cause error
```shell
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/
```

- Update Docker CLI version from 28.2.2 to 20.10.24
- Update Go version from1.22 to 1.24 in buildpack action
- Update buildpack action image to latest version

@sfwn 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [ ] My change is adequately tested.
