### PR TITLE
fix(image-check): update image format validation in workflow

### DIFF
--- a/.github/workflows/image-check.yml
+++ b/.github/workflows/image-check.yml
@@ -16,12 +16,12 @@ jobs:
           ERDA_REGISTRY: registry.erda.cloud
         run: |
           repo_name=`echo ${{ github.repository }} | awk -F "/" '{print $2}'`
-          echo "standard image format: $ERDA_REGISTRY/$repo_name/extension_name:tag"
+          echo "standard image format: $ERDA_REGISTRY/{erda|erda-*}/extension_name:tag"
 
           failed=false
 
           for file in `find . -name $EXT_FILE_NAME`; do
-              res=$(cat $file | grep "image:" | grep -vi "$ERDA_REGISTRY/$repo_name/" | awk '{print $2}')
+              res=$(cat $file | grep "image:" | grep -vi -E "$ERDA_REGISTRY/erda(/|-)" | awk '{print $2}')
               if [ -n "$res" ]; then
                   failed=true
                   echo "[FAILED] illegal image: $res, path: $file"


### PR DESCRIPTION
## Description

Refines the image format check to match images under 'erda' or 'erda-*' namespaces in the registry, improving accuracy of illegal image detection in the CI workflow.


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.
