### PR TITLE
feat(golang): update golang action base images and dependencies

### DIFF
--- a/actions/golang/1.0/Dockerfile
+++ b/actions/golang/1.0/Dockerfile
@@ -1,4 +1,6 @@
-FROM --platform=$TARGETPLATFORM registry.erda.cloud/erda-actions/custom-script:2.0 as builder
+FROM registry.erda.cloud/erda-x/golang:1.24 AS builder
+
+ENV CGO_ENABLED=0
 
 COPY . /go/src/github.com/erda-project/erda-actions
 WORKDIR /go/src/github.com/erda-project/erda-actions
@@ -7,7 +9,13 @@ RUN mkdir -p /opt/action/comp && cp -r actions/golang/1.0/comp/* /opt/action/com
 
 RUN go build -o /assets/run /go/src/github.com/erda-project/erda-actions/actions/golang/1.0/internal/cmd/main.go
 
-FROM --platform=$TARGETPLATFORM registry.erda.cloud/erda-actions/custom-script:2.0
+FROM registry.erda.cloud/retag/buildkit:v0.11.6 AS buildkit
+FROM registry.erda.cloud/retag/docker:20.10.24-cli AS docker-cli
+FROM registry.erda.cloud/erda-x/golang:1.24
 
 COPY --from=builder /opt/action/comp /opt/action/comp
 COPY --from=builder /assets /opt/action
+COPY --from=buildkit /usr/bin/buildctl /usr/bin/buildctl
+COPY --from=docker-cli /usr/local/bin/docker /usr/bin/docker
+
+RUN chmod +x /opt/action/run

--- a/actions/golang/1.0/comp/Dockerfile
+++ b/actions/golang/1.0/comp/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.erda.cloud/erda/terminus-golang:1.19.7
+FROM registry.erda.cloud/erda-x/debian-bookworm:12
 
 ARG TARGET
 

--- a/actions/golang/1.0/dice.yml
+++ b/actions/golang/1.0/dice.yml
@@ -1,7 +1,7 @@
 ### job 配置项
 jobs:
   golang:
-    image: registry.erda.cloud/erda-actions/golang-action:1.0-20230818184443-368edf36
+    image: registry.erda.cloud/erda-actions/golang-action:1.0-20260303175900-21fff627
     resources:
       cpu: 0.5
       mem: 1024


### PR DESCRIPTION
## Description

- Replace terminus-golang:1.19.7 with debian-bookworm:12 in comp Dockerfile
- Update action image tag from 1.0-20230818184443-368edf36 to 1.0-20260303175900-21fff627
- Change base image from custom-script:2.0 to golang:1.24 in main Dockerfile
- Add CGO_ENABLED=0 environment variable
- Introduce buildkit and docker-cli multi-stage builds
- Copy buildctl and docker binaries to final image
- Set executable permissions for run binary

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to check the compatibility of the erda version statemented in the action's spec.yml.
 - [x] My change is adequately tested.

@sfwn @luobily 