### PR TITLE
feat(terminus-nodejs): add deploy.sh for node 22.22.2

### DIFF
--- a/dockerfiles/terminus-nodejs/node.22.22.2/Dockerfile.debian.npm.11.0
+++ b/dockerfiles/terminus-nodejs/node.22.22.2/Dockerfile.debian.npm.11.0
@@ -1,0 +1,59 @@
+# Git: git version 2.39.2, gcc: 12.2.0, curl: 7.88.1, Wget: 1.21.3, Python 3.11.2
+# Node: 22.22.2 LTS, npm: 11.0.0, yarn: 1.22.19, pnpm: 9.1.3, fnm: 1.36.0
+# /etc/os-release: Debian GNU/Linux 12 (bookworm)
+# Linux e2a008c89a1c 6.4.16-linuxkit #1 SMP PREEMPT_DYNAMIC Thu Nov 16 UTC 2023 x86_64 GNU/Linux
+# Build cmd: docker build . -t terminus/debian-node-22.22.2 -f Dockerfile.debian.npm.11.0 --no-cache
+# Other tags: terminus/debian-node:22.22.2-lts,terminus/debian-node:22.22.2
+FROM node:22.22.2-bookworm-slim
+
+LABEL maintainer=hustcer<majun@terminus.io>
+
+# Use mirrors to speed up installation
+RUN apt update \
+    && apt upgrade -y \
+    && apt install apt-transport-https ca-certificates locales -y --no-install-recommends --no-install-suggests \
+    # Change locale & timezone
+    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+    && echo "zh_CN.UTF-8 UTF-8" >> /etc/locale.gen \
+    && locale-gen \
+    && echo 'deb https://mirrors.aliyun.com/debian/ bookworm main non-free non-free-firmware contrib' > /etc/apt/sources.list \
+    && echo 'deb https://mirrors.aliyun.com/debian-security/ bookworm-security main' >> /etc/apt/sources.list \
+    && echo 'deb https://mirrors.aliyun.com/debian/ bookworm-updates main non-free non-free-firmware contrib' >> /etc/apt/sources.list \
+    && echo 'deb https://mirrors.aliyun.com/debian/ bookworm-backports main non-free non-free-firmware contrib' >> /etc/apt/sources.list \
+    && echo 'deb-src https://mirrors.aliyun.com/debian/ bookworm main non-free non-free-firmware contrib' >> /etc/apt/sources.list \
+    && echo 'deb-src https://mirrors.aliyun.com/debian-security/ bookworm-security main' >> /etc/apt/sources.list \
+    && echo 'deb-src https://mirrors.aliyun.com/debian/ bookworm-updates main non-free non-free-firmware contrib' >> /etc/apt/sources.list \
+    && echo 'deb-src https://mirrors.aliyun.com/debian/ bookworm-backports main non-free non-free-firmware contrib' >> /etc/apt/sources.list
+
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV NODEJS_ORG_MIRROR="https://npmmirror.com/dist"
+ENV SASS_BINARY_SITE="https://npmmirror.com/mirrors/node-sass"
+
+RUN npm config set @terminus:registry https://registry.npm.terminus.io/  \
+    && npm config set registry https://registry.npmmirror.com/ \
+    && apt update \
+    && apt install -y --no-install-recommends --no-install-suggests \
+       git curl wget bzip2 unzip openssh-client gcc make g++ python3 \
+    # Make /bin/sh symlink to bash instead of dash:
+    # REF: https://groups.google.com/g/linux.debian.user/c/2CyfM5UrSOI?pli=1
+    && dpkg-divert --remove --no-rename /usr/share/man/man1/sh.1.gz \
+    && dpkg-divert --remove --no-rename /bin/sh \
+    && ln -sf bash.1.gz /usr/share/man/man1/sh.1.gz \
+    && ln -sf bash /bin/sh \
+    && dpkg-divert --add --local --no-rename /usr/share/man/man1/sh.1.gz \
+    && dpkg-divert --add --local --no-rename /bin/sh \
+    # fnm --- Reserved expansion point:
+    # See: https://github.com/Schniz/fnm, Fast and simple Node version manager
+    # Make it easier and faster to switch to other node versions in the future
+    # Just do: fnm install 16 && fnm use 16, will finish in 10 seconds.
+    && curl -fsSL https://fnm.vercel.app/install | bash \
+    # Fix: fnm can't infer your shell based on the process tree.
+    && sed -i 's/fnm env/fnm env --shell=bash/' /root/.bashrc \
+    && npm i -g pnpm@latest \
+    # Fix "Unable to find the global bin directory" error while running `pnpm i -g`
+    && pnpm config set global-bin-dir '/usr/local/bin' \
+    && rm -rf /var/lib/apt/lists/* && apt autoremove -y \
+    # Make /bin/sh symlink to bash instead of dash:
+    && echo "dash dash/sh boolean false" | debconf-set-selections \
+    && DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash

--- a/dockerfiles/terminus-nodejs/node.22.22.2/deploy.sh
+++ b/dockerfiles/terminus-nodejs/node.22.22.2/deploy.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+image=registry.erda.cloud/erda-actions/terminus-debian-node:22.22.2-lts
+
+docker buildx build --platform linux/amd64,linux/arm64 -t ${image} --push . -f Dockerfile.debian.npm.11.0
+
+echo "action meta: terminus-debian-node=$image"


### PR DESCRIPTION
## Summary
为 `dockerfiles/terminus-nodejs/node.22.22.2` 目录补充 `deploy.sh`，参考 node.20.11 的结构。

## Changes
- 新增 `deploy.sh`：构建并推送 `terminus-debian-node:22.22.2-lts` 镜像

## Files Changed
- `dockerfiles/terminus-nodejs/node.22.22.2/deploy.sh` (新增)
- `dockerfiles/terminus-nodejs/node.22.22.2/Dockerfile.debian.npm.11.0` (已存在)