### PR TITLE
fix: remove syntax directive from Node Dockerfiles to fix multi-arch build

### DIFF
--- a/dockerfiles/terminus-nodejs/node.22.22/Dockerfile.debian.npm.10.9
+++ b/dockerfiles/terminus-nodejs/node.22.22/Dockerfile.debian.npm.10.9
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:latest
-
 # Node: 22.22.2, npm: 10.9.7, pnpm: 10.33.4, Git: 2.47.3, fnm: 1.39.0
 # Bash: 5.2.37, Wget: 1.25.0, curl: 8.14.1, gcc: 14.2.0, Python: 3.13
 # /etc/os-release: Debian GNU/Linux 13.4 (trixie)

--- a/dockerfiles/terminus-nodejs/node.24.15/Dockerfile.debian.npm.11.12
+++ b/dockerfiles/terminus-nodejs/node.24.15/Dockerfile.debian.npm.11.12
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:latest
-
 # Node: 24.15.0, npm: 11.12.1, pnpm: 10.33.4, Git: 2.47.3, fnm: 1.39.0
 # Bash: 5.2.37, Wget: 1.25.0, curl: 8.14.1, gcc: 14.2.0, Python: 3.13
 # /etc/os-release: Debian GNU/Linux 13.4 (trixie)


### PR DESCRIPTION
## Description

fix: remove syntax directive from Node Dockerfiles to fix multi-arch build

## Checklist
